### PR TITLE
chore (repo): Add codeowners file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+# The codebase is owned by the Governance & Identity Experience team at DFINITY
+# For questions, reach out to: <gix@dfinity.org>
+.github/CODEOWNERS @dfinity/gix
+# The GIX team members who maintain this repo:
+* @bitdivine


### PR DESCRIPTION
# Motivation
We are required to have a CODEOWNERS file that lists the GIX team as owners.

However most GIX team members don't work on this repository and typically notifications about projects one is not involved in are essentially spam.


# Changes
- Make the CODEOWNERS file owned by GIX, so that GIX is alerted to any attempt to change ownership.
- Make @bitdivine, currently the sole developer, the owner of other files.

# Tests
See CI