### PR TITLE
feat(devops): Upload release artefacts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,8 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-tags: true
+      - name: Show tags
+        run: git tag --points-at HEAD
       - name: Build
         uses: ./.github/actions/build
       - name: Release


### PR DESCRIPTION
# Motivation
When the release workflow runs, it should upload the build artefacts to the release tag.

# Changes
- Uplaod the build artefacts

# Tests
See: https://github.com/dfinity/chain-fusion-signer/releases/tag/untagged-3c6efeb1c8c17724bf3c