### PR TITLE
feat(devops): Allow formatting differences in autogenerated files

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -25,7 +25,7 @@ jobs:
         run: ./scripts/fmt
       - name: Check formatted
         run: |
-          test -z "$(git status --porcelain)" || {
+          test -z "$(git status --porcelain | grep -v --file .relaxedfmt)" || {
                   echo "FIX: Please run ./scripts/fmt"
                   git diff
                   exit 1

--- a/.relaxedfmt
+++ b/.relaxedfmt
@@ -1,0 +1,1 @@
+package-lock.json


### PR DESCRIPTION
# Motivation
`package-lock.json` can be populated automatically by dependabot.  But the dependabot JSON indentation differs from our default.  This causes dependabot PRs to fail CI.

# Changes
- Allow formatting differences in the `package-lock.json`.

# Tests
The key  command has been tested locally.  Soon dependabot PRs should also turn green.