### PR TITLE
fix(devops): Generate only example-backend types

### DIFF
--- a/src/example-frontend/package.json
+++ b/src/example-frontend/package.json
@@ -6,7 +6,7 @@
 	"scripts": {
 		"setup": "npm i && dfx canister create example-backend && dfx generate example-backend && dfx deploy",
 		"start": "vite --port 3000",
-		"prebuild": "dfx generate",
+		"prebuild": "dfx generate example-backend",
 		"build": "tsc && vite build",
 		"format": "prettier --write \"src/**/*.{json,js,jsx,ts,tsx,css,scss}\""
 	},

--- a/src/example-frontend/src/App.js
+++ b/src/example-frontend/src/App.js
@@ -4,7 +4,7 @@ import {
 	example_backend,
 	idlFactory as exampleBackendIdlFactory
 } from 'declarations/example-backend';
-import { idlFactory as icSignerIdlFactory } from 'declarations/signer';
+import { idlFactory as icSignerIdlFactory } from '../../declarations/signer';
 import { html, render } from 'lit-html';
 import logo from './logo2.svg';
 

--- a/src/example-frontend/src/App.js
+++ b/src/example-frontend/src/App.js
@@ -4,8 +4,8 @@ import {
 	example_backend,
 	idlFactory as exampleBackendIdlFactory
 } from 'declarations/example-backend';
-import { idlFactory as icSignerIdlFactory } from '../../declarations/signer';
 import { html, render } from 'lit-html';
+import { idlFactory as icSignerIdlFactory } from '../../declarations/signer';
 import logo from './logo2.svg';
 
 class App {


### PR DESCRIPTION
# Motivation

There was an error in the CI pipeline: https://github.com/dfinity/chain-fusion-signer/actions/runs/10792950208/job/29933752501?pr=41

The error comes from trying to generate the types of all canisters instead only the example backend.

# Changes

* Example frontend only generates types of `example-backend`.

# Tests

Let's see CI tests.
