### PR TITLE
feat(devops): Install more tools in docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,8 +42,9 @@ COPY ./rust-toolchain.toml .
 ENV RUSTUP_HOME=/opt/rustup \
     CARGO_HOME=/cargo \
     PATH=/cargo/bin:$PATH
-COPY scripts/setup-rust scripts/setup-rust
-RUN scripts/setup-rust
+COPY dev-tools.json dev-tools.json
+COPY scripts/setup scripts/setup-cargo-binstall scripts/setup-rust scripts/
+RUN scripts/setup rust cargo-binstall candid-extractor ic-wasm
 # Optional: Pre-build dependencies
 COPY Cargo.lock .
 COPY Cargo.toml .

--- a/dev-tools.json
+++ b/dev-tools.json
@@ -5,6 +5,10 @@
 		"url": "https://raw.githubusercontent.com/rust-lang/rustup/1.25.2/rustup-init.sh",
 		"pipe": [["sh"]]
 	},
+	"rust": {
+		"method": "sh",
+		"version": "See rust-toolchain.toml"
+	},
 	"n": {
 		"method": "curl",
 		"version": "v9.0.1",
@@ -27,6 +31,10 @@
 	"cargo-binstall": {
 		"method": "sh",
 		"version": "1.7.4"
+	},
+	"ic-wasm": {
+		"method": "cargo-binstall",
+		"version": "0.3.6"
 	},
 	"cargo-audit": {
 		"method": "cargo-binstall",


### PR DESCRIPTION
# Motivation
We need to build Wasms directly - unfortunately.  So here we install the requisite tools.

# Changes
- Install `candid-extractor` and `ic-wasm` in the docker builder image.
- Add these two tools to the list that can be installed with `setup`.

# Tests
See CI