### PR TITLE
fix(devops): Remove docker-hash warning messages

### DIFF
--- a/scripts/docker-hashes
+++ b/scripts/docker-hashes
@@ -5,4 +5,4 @@
 # * The AWK code also adds a header and footer;
 # * `column -t` formats the data as a table;
 # * `tee` saves a copy of the printout in a file; that file will be included in releases.
-find out/ -type f -print0 | xargs sha256sum | awk '{"wc -c " $2 | getline size; print $1, size}BEGIN{print "===START_ARTEFACTS===\nsha256 size filename"}END{print "==END_ARTEFACTS=="}' | column -t | tee out/filelist.txt
+find out/ -type f -print0 | grep -vz filelist.txt | xargs --null sha256sum | awk '{"wc -c " $2 | getline size; print $1, size}BEGIN{print "===START_ARTEFACTS===\nsha256 size filename"}END{print "==END_ARTEFACTS=="}' | column -t | tee out/filelist.txt


### PR DESCRIPTION
# Motivation
The docker build emits some strange values at the end.

# Changes
- Address the xargs warning by telling it to expect nulls in the input
- Address the shasum of the incomple file-of-hashes by omitting that file from those being hashed.

# Tests
See CI.  No more warnings