### PR TITLE
fix(devops): Ignore the docker output file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,9 @@
 # rust
 target/
 
+# docker buildx
+out
+
 # frontend code
 node_modules/
 dist/


### PR DESCRIPTION
# Motivation
docker buildx puts files in an `out` directory.  This is not included in `.gitignore`, so causes spurious warnings about diffs.

# Changes
- Ignore the out directory.

# Tests
See CI