### PR TITLE
fix(devops): Lock dependencies in the prebuild

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -58,7 +58,7 @@ RUN mkdir -p src/signer/src \
     && touch src/shared/src/lib.rs \
     && mkdir -p src/example-backend/src \
     && touch src/example-backend/src/lib.rs \
-    && cargo build --target wasm32-unknown-unknown \
+    && cargo build --locked --target wasm32-unknown-unknown \
     && rm -rf src
 
 


### PR DESCRIPTION
# Motivation
In eth dockerfile, where the libraries are pre-build, `--locked` is not passed, which may cause different libraries to be prebuilt.

# Changes
- Lock the prebuild dependencies.

# Tests
See CI