### PR TITLE
fix(devops): Fix local bitcoin deployment

### DIFF
--- a/dfx.json
+++ b/dfx.json
@@ -12,11 +12,12 @@
 		"bitcoin": {
 			"type": "custom",
 			"wasm": "https://github.com/dfinity/bitcoin-canister/releases/download/release%2F2024-08-30/ic-btc-canister.wasm.gz",
-			"candid": "https://raw.githubusercontent.com/dfinity/bitcoin-canister/master/canister/candid.did",
+			"candid": "https://raw.githubusercontent.com/dfinity/bitcoin-canister/release/2024-08-30/canister/candid.did",
+			"specified_id": "g4xu7-jiaaa-aaaan-aaaaq-cai",
+			"init_arg_file": "init/bitcoin",
 			"remote": {
 				"id": {
-					"ic": "g4xu7-jiaaa-aaaan-aaaaq-cai",
-					"local": "g4xu7-jiaaa-aaaan-aaaaq-cai"
+					"ic": "g4xu7-jiaaa-aaaan-aaaaq-cai"
 				}
 			}
 		},

--- a/init/bitcoin
+++ b/init/bitcoin
@@ -1,0 +1,14 @@
+(
+  record {
+    api_access = null;
+    lazily_evaluate_fee_percentiles = null;
+    blocks_source = null;
+    fees = null;
+    watchdog_canister = null;
+    network = null;
+    stability_threshold = null;
+    syncing = null;
+    burn_cycles = null;
+    disable_api_if_not_fully_synced = null;
+  },
+)


### PR DESCRIPTION
# Motivation
`dfx deploy` is breaking erratically.  `dfx deploy bitcoin` is breaking consistently.  This is because it is using a remote canister id for `local`, instead of a `specified_id`.

# Changes
- Remove the bitcoin remote canister id for `local`.
- Add a specified canister id for bitcoin.
- Add a default init arg for bitcoin.

# Tests
`dfx deploy bitcoin` now works, even ina completely clean repo.  It is yet to be seen whether this resolves the erratic `dfx deploy` breakages.