### PR TITLE
refactor(devops): Improve WASM source in tests

### DIFF
--- a/scripts/test.backend.sh
+++ b/scripts/test.backend.sh
@@ -3,28 +3,28 @@
 POCKET_IC_SERVER_VERSION=5.0.0
 UPGRADE_VERSIONS="v0.0.13,v0.0.19,v0.0.25"
 BITCOIN_CANISTER_RELEASE="2024-08-30"
+BITCON_CANISTER_WASM="ic-btc-canister.wasm.gz"
+SIGNER_CANISTER_WASM="signer.wasm"
 
-# If a signer wasm file exists at the root, it will be used for the tests.
-
-if [ -f "./signer.wasm.gz" ]; then
-  # Setting the environment variable will be used in the test to load that particular file. Relative to where the test is.
-  echo "Use existing signer.wasm.gz canister."
-  export BACKEND_WASM_PATH="../../signer.wasm.gz"
+if [ -f "./$SIGNER_CANISTER_WASM" ]; then
+  echo "Use existing $SIGNER_CANISTER_WASM canister."
+  # If a signer wasm file exists at the root, it will be used for the tests.
+  export SIGNER_CANISTER_WASM_FILE="/$SIGNER_CANISTER_WASM"
 else
-  # If none exist we build the project. The test will resolve the target/wasm32-unknown-unknown/release/signer.wasm automatically as fallback if no exported BACKEND_WASM_PATH variable is set.
   echo "Building signer canister."
   cargo build --locked --target wasm32-unknown-unknown --release -p signer
+  # Otherwise, the new wasm file will be used.
+  export SIGNER_CANISTER_WASM_FILE="/target/wasm32-unknown-unknown/release/$SIGNER_CANISTER_WASM"
 fi
 
-if [ -f "./ic-btc-canister.wasm.gz" ]; then
-  # Setting the environment variable will be used in the test to load that particular file. Relative to where the test is.
-  echo "Use existing ic-btc-canister.wasm.gz canister."
-  export BITCOIN_CANISTER_WASM_PATH="../../ic-btc-canister.wasm.gz"
+if [ -f "./$BITCON_CANISTER_WASM" ]; then
+  echo "Use existing $BITCON_CANISTER_WASM canister."
 else
-  # If none exist we build the project. The test will resolve the target/wasm32-unknown-unknown/release/bitcoin_canister.wasm automatically as fallback if no exported BITCOIN_CANISTER_WASM_PATH variable is set.
   echo "Downloading bitcoin_canister canister."
-  curl -sSL "https://github.com/dfinity/bitcoin-canister/releases/download/release%2F$BITCOIN_CANISTER_RELEASE/ic-btc-canister.wasm.gz" -o "ic-btc-canister.wasm.gz"
+  curl -sSL "https://github.com/dfinity/bitcoin-canister/releases/download/release%2F$BITCOIN_CANISTER_RELEASE/ic-btc-canister.wasm.gz" -o $BITCON_CANISTER_WASM
 fi
+# Setting the environment variable that will be used in the test to load that particular file relative to the cargo workspace.
+export BITCOIN_CANISTER_WASM_FILE="/$BITCON_CANISTER_WASM"
 
 # We use a previous version of the release to ensure upgradability
 

--- a/src/signer/tests/it/utils/pocketic.rs
+++ b/src/signer/tests/it/utils/pocketic.rs
@@ -4,13 +4,27 @@ use pocket_ic::{CallError, PocketIc, PocketIcBuilder, WasmResult};
 use serde::Deserialize;
 use shared::types::{Arg, InitArg};
 use std::fs::read;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::{env, time::Duration};
 
 use super::mock::CONTROLLER;
 
-const BACKEND_WASM: &str = "../../target/wasm32-unknown-unknown/release/signer.wasm";
-const BITCOIN_WASM: &str = "../../ic-btc-canister.wasm.gz";
+fn workspace_dir() -> PathBuf {
+    let output = std::process::Command::new(env!("CARGO"))
+        .arg("locate-project")
+        .arg("--workspace")
+        .arg("--message-format=plain")
+        .output()
+        .unwrap()
+        .stdout;
+    let cargo_path = Path::new(std::str::from_utf8(&output).unwrap().trim());
+    cargo_path.parent().unwrap().to_path_buf()
+}
+
+// Default file paths relative to the cargo workspace.
+const DEFAULT_SIGNER_WASM: &str = "/target/wasm32-unknown-unknown/release/signer.wasm";
+const DEFAULT_BITCOIN_WASM: &str = "/ic-btc-canister.wasm.gz";
 const BITCOIN_CANISTER_ID: &str = "g4xu7-jiaaa-aaaan-aaaaq-cai";
 
 // This is necessary to deploy the bitcoin canister.
@@ -82,20 +96,36 @@ impl BackendBuilder {
     /// To override, please use `with_cycles()`.
     pub const DEFAULT_CYCLES: u128 = 2_000_000_000_000;
     /// The default Wasm file to deploy:
-    /// - If the environment variable `BACKEND_WASM_PATH` is set, it will use that path.
-    /// - Otherwise, it will use the `BACKEND_WASM` constant.
+    /// - If the environment variable `SIGNER_CANISTER_WASM_FILE` is set, it will use that path.
+    /// - Otherwise, it will use the `DEFAULT_SIGNER_WASM` constant.
     ///
     /// To override, please use `with_wasm()`.
     pub fn default_wasm_path() -> String {
-        env::var("BACKEND_WASM_PATH").unwrap_or_else(|_| BACKEND_WASM.to_string())
+        let workspace_dir_str = workspace_dir()
+        .to_str()
+        .expect("Wrong workspace directory")
+        .to_owned();
+    
+        let wasm_name = env::var("SIGNER_CANISTER_WASM_FILE")
+            .unwrap_or_else(|_| DEFAULT_SIGNER_WASM.to_string());
+
+        workspace_dir_str + &wasm_name
     }
     /// The default Wasm file to deploy the bitcoin canister:
-    /// - If the environment variable `BITCOIN_WASM_PATH` is set, it will use that path.
-    /// - Otherwise, it will use the `BITCOIN_WASM` constant.
+    /// - If the environment variable `BITCOIN_CANISTER_WASM_FILE` is set, it will use that path.
+    /// - Otherwise, it will use the `DEFAULT_BITCOIN_WASM` constant.
     ///
     /// To override, please use `with_wasm()`.
     pub fn default_bitcoin_wasm_path() -> String {
-        env::var("BITCOIN_WASM_PATH").unwrap_or_else(|_| BITCOIN_WASM.to_string())
+        let workspace_dir_str = workspace_dir()
+            .to_str()
+            .expect("Wrong workspace directory")
+            .to_owned();
+        
+        let wasm_name = env::var("BITCOIN_CANISTER_WASM_FILE")
+            .unwrap_or_else(|_| DEFAULT_BITCOIN_WASM.to_string());
+    
+        workspace_dir_str + &wasm_name
     }
     /// The default arguments to deploy the bitcoin canister.
     pub fn default_bitcoin_arg() -> Vec<u8> {
@@ -280,7 +310,7 @@ impl PicSigner {
     #[allow(dead_code)]
     pub fn upgrade_latest_wasm(&self, encoded_arg: Option<Vec<u8>>) -> Result<(), String> {
         let backend_wasm_path =
-            env::var("BACKEND_WASM_PATH").unwrap_or_else(|_| BACKEND_WASM.to_string());
+            env::var("BACKEND_WASM_PATH").unwrap_or_else(|_| DEFAULT_SIGNER_WASM.to_string());
 
         self.upgrade_with_wasm(&backend_wasm_path, encoded_arg)
     }

--- a/src/signer/tests/it/utils/pocketic.rs
+++ b/src/signer/tests/it/utils/pocketic.rs
@@ -102,10 +102,10 @@ impl BackendBuilder {
     /// To override, please use `with_wasm()`.
     pub fn default_wasm_path() -> String {
         let workspace_dir_str = workspace_dir()
-        .to_str()
-        .expect("Wrong workspace directory")
-        .to_owned();
-    
+            .to_str()
+            .expect("Wrong workspace directory")
+            .to_owned();
+
         let wasm_name = env::var("SIGNER_CANISTER_WASM_FILE")
             .unwrap_or_else(|_| DEFAULT_SIGNER_WASM.to_string());
 
@@ -121,10 +121,10 @@ impl BackendBuilder {
             .to_str()
             .expect("Wrong workspace directory")
             .to_owned();
-        
+
         let wasm_name = env::var("BITCOIN_CANISTER_WASM_FILE")
             .unwrap_or_else(|_| DEFAULT_BITCOIN_WASM.to_string());
-    
+
         workspace_dir_str + &wasm_name
     }
     /// The default arguments to deploy the bitcoin canister.


### PR DESCRIPTION
# Motivation

Make tests more reliable instead of relying in relative paths.

# Changes

* Change the wasm paths to be relative to the cargo workspace instead of relative to the test file.
* Set the env vars in `test.backend.sh` accordingly.

# Tests

Running `test.backend.sh` with different wasm file names works.
