### PR TITLE
refactor(devops): Use a custom build command for the signer

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -86,6 +86,8 @@ jobs:
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-1
       - name: Install dfx
         uses: dfinity/setup-dfx@main
+      - name: Install build tools
+        run: scripts/setup cargo-binstall candid-extractor ic-wasm
       - name: Start dfx
         run: dfx start --clean --background
       - name: Deploy all canisters

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -11,7 +11,7 @@ defaults:
 jobs:
   format:
     name: 'Format'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     env:
       TITLE: ${{ github.event.pull_request.title }}
     steps:
@@ -34,7 +34,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-20.04]
+        os: [ubuntu-22.04]
     steps:
       - uses: actions/checkout@v4
       - name: Have relevant files changed?
@@ -66,7 +66,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-20.04]
+        os: [ubuntu-22.04]
     steps:
       - uses: actions/checkout@v4
       - name: Have relevant files changed?
@@ -97,7 +97,7 @@ jobs:
   check-pass:
     needs: ["format", "rust-tests", "installation"]
     if: ${{ always() }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/needs_success

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -11,7 +11,7 @@ defaults:
 jobs:
   integration:
     name: Integration tests
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   pr:
     name: 'PR'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     env:
       TITLE: ${{ github.event.pull_request.title }}
     steps:
@@ -29,7 +29,7 @@ jobs:
   pr-pass:
     needs: ["pr"]
     if: ${{ always() }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/needs_success

--- a/.github/workflows/reproducible-native.yaml
+++ b/.github/workflows/reproducible-native.yaml
@@ -80,7 +80,7 @@ jobs:
   reproducible_build_passes:
     needs: ["build", "compare_hashes"]
     if: ${{ always() }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/needs_success

--- a/dfx.json
+++ b/dfx.json
@@ -2,11 +2,10 @@
 	"dfx": "0.23.0",
 	"canisters": {
 		"signer": {
+			"type": "custom",
+			"build": "scripts/build.signer.sh",
 			"candid": "src/signer/signer.did",
-			"package": "signer",
-			"type": "rust",
-			"optimize": "cycles",
-			"gzip": true,
+			"wasm": "target/signer.wasm.gz",
 			"init_arg": "(variant { Init = record { ecdsa_key_name = \"key_1\"; ic_root_key_der = null;}})"
 		},
 		"bitcoin": {

--- a/dfx.json
+++ b/dfx.json
@@ -27,7 +27,7 @@
 		},
 		"example_frontend": {
 			"build": "npm ci && npm run build",
-			"dependencies": ["example_backend"],
+			"dependencies": ["example_backend", "signer"],
 			"source": ["src/example_frontend/dist"],
 			"type": "assets",
 			"workspace": "example_frontend"

--- a/scripts/build.signer.sh
+++ b/scripts/build.signer.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+print_help() {
+  cat <<-EOF
+	Creates the Chain Fusion Signer installation files:
+
+	- The Wasm and Candid files are built.
+
+	The files are installed at the locations defined for 'signer' in 'dfx.json'.
+	EOF
+}
+
+[[ "${1:-}" != "--help" ]] || {
+  print_help
+  exit 0
+}
+
+DFX_NETWORK="${DFX_NETWORK:-local}"
+
+CANDID_FILE="$(jq -r .canisters.signer.candid dfx.json)"
+WASM_FILE="$(jq -r .canisters.signer.wasm dfx.json)"
+
+####
+# Builds the Wasm without metadata
+cargo build --locked --target wasm32-unknown-unknown --release -p signer
+
+####
+# Builds the candid file
+mkdir -p "$(dirname "$WASM_FILE")"
+candid-extractor "target/wasm32-unknown-unknown/release/signer.wasm" >"$CANDID_FILE"
+
+####
+# Optimize Wasm and set metadata
+ic-wasm \
+  "target/wasm32-unknown-unknown/release/signer.wasm" \
+  -o "target/wasm32-unknown-unknown/release/signer.optimized.wasm" \
+  shrink
+
+# adds the content of $canister.did to the `icp:public candid:service` custom section of the public metadata in the wasm
+ic-wasm "target/wasm32-unknown-unknown/release/signer.optimized.wasm" -o "target/wasm32-unknown-unknown/release/signer.metadata.wasm" metadata candid:service -f "$CANDID_FILE" -v public
+
+gzip -fn "target/wasm32-unknown-unknown/release/signer.metadata.wasm"
+
+mv "target/wasm32-unknown-unknown/release/signer.metadata.wasm.gz" "$WASM_FILE"
+
+####
+# Success
+cat <<EOF
+SUCCESS: The signer installation files have been created:
+signer candid:       $(sha256sum "$CANDID_FILE")
+signer Wasm:         $(sha256sum "$WASM_FILE")
+EOF


### PR DESCRIPTION
# Motivation
We would like to use a custom build command for the signer so that we can add post-build commands.

# Changes
- Create a custom build command that creates the signer Wasm and candid files.

# Tests
Existing CI should suffice