### PR TITLE
fix(devops): Update dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -51,7 +51,6 @@ COPY Cargo.toml .
 COPY src/signer/Cargo.toml src/signer/Cargo.toml
 COPY src/example_backend/Cargo.toml src/example_backend/Cargo.toml
 COPY src/shared/Cargo.toml src/shared/Cargo.toml
-ENV CARGO_TARGET_DIR=/cargo_target
 RUN mkdir -p src/signer/src \
     && touch src/signer/src/lib.rs \
     && mkdir -p src/shared/src \
@@ -80,6 +79,7 @@ FROM builder AS build-signer
 COPY src src
 COPY dfx.json dfx.json
 COPY canister_ids.json canister_ids.json
+COPY scripts/build.signer.sh scripts/build.signer.args.sh scripts/
 RUN touch src/*/src/*.rs
 RUN dfx build --ic signer
 RUN cp .dfx/ic/canisters/signer/signer.wasm.gz /signer.wasm.gz


### PR DESCRIPTION
# Motivation
The signer build has been updated; the dockerfile is broken and needs to be updated to match.

# Changes
- Add the new signer build scripts to the dockerfile
- Use the standard `CARGO_TARGET_DIR` to keep the same behaviour between Docker and native builds.

# Tests
`./scripts/docker-build` works.  This is exercised in releases but not every PR.