### PR TITLE
feat(devops): Put native and docker builds in the same place

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -82,8 +82,9 @@ COPY canister_ids.json canister_ids.json
 COPY scripts/build.signer.sh scripts/build.signer.args.sh scripts/
 RUN touch src/*/src/*.rs
 RUN dfx build --ic signer
-RUN cp .dfx/ic/canisters/signer/signer.wasm.gz /signer.wasm.gz
-RUN sha256sum /signer.wasm.gz
+RUN cp out/signer.wasm.gz out/signer.args.did /
+RUN sha256sum /signer.wasm.gz /signer.args.did
 
 FROM scratch AS signer
 COPY --from=build-signer /signer.wasm.gz /
+COPY --from=build-signer /signer.args.did /

--- a/dfx.json
+++ b/dfx.json
@@ -5,8 +5,8 @@
 			"type": "custom",
 			"build": "scripts/build.signer.sh",
 			"candid": "src/signer/signer.did",
-			"wasm": "target/signer.wasm.gz",
-			"init_arg_file": "target/signer.arg.did"
+			"wasm": "out/signer.wasm.gz",
+			"init_arg_file": "out/signer.args.did"
 		},
 		"bitcoin": {
 			"type": "custom",

--- a/scripts/build.signer.sh
+++ b/scripts/build.signer.sh
@@ -46,6 +46,7 @@ ic-wasm "$BUILD_DIR/signer.optimized.wasm" -o "$BUILD_DIR/signer.metadata.wasm" 
 
 gzip -fn "$BUILD_DIR/signer.metadata.wasm"
 
+mkdir -p "$(dirname "$WASM_FILE")"
 mv "$BUILD_DIR/signer.metadata.wasm.gz" "$WASM_FILE"
 
 ####


### PR DESCRIPTION
# Motivation
If we put native and docker builds in the same place, `dfx build signer` and `scripts/docker-build` become interchangeable.

# Changes
- Put native build artefacts in `out`, in the same place as the docker builds.

# Tests
See CI