### PR TITLE
chore(devops): Update the release version to 0.1.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -594,7 +594,7 @@ dependencies = [
 
 [[package]]
 name = "example_backend"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "candid",
  "ic-cdk 0.15.1",
@@ -1072,7 +1072,7 @@ dependencies = [
 
 [[package]]
 name = "ic-chain-fusion-signer-api"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "candid",
  "ic-canister-sig-creation",
@@ -2293,7 +2293,7 @@ dependencies = [
 
 [[package]]
 name = "signer"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "bitcoin",
  "candid",

--- a/src/example_backend/Cargo.toml
+++ b/src/example_backend/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "example_backend"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/src/signer/api/Cargo.toml
+++ b/src/signer/api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ic-chain-fusion-signer-api"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2021"
 
 [dependencies]

--- a/src/signer/canister/Cargo.toml
+++ b/src/signer/canister/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "signer"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
# Motivation
There have been significant changes since the last release, in particular simplifying and cleaning up code.  So it is time for a new release.

# Changes
- Update the release version to 0.1.4

# Tests
See CI