### PR TITLE
feat(signer): Change API to make it backwards compatible

### DIFF
--- a/src/signer/api/src/types.rs
+++ b/src/signer/api/src/types.rs
@@ -42,3 +42,46 @@ pub mod transaction {
         pub data: Option<String>,
     }
 }
+
+pub mod bitcoin {
+    use candid::{CandidType, Deserialize, Nat};
+    use ic_cdk::api::management_canister::bitcoin::BitcoinNetwork;
+
+    #[derive(CandidType, Deserialize, Debug)]
+    pub enum BitcoinAddressType {
+        P2WPKH,
+    }
+
+    #[derive(CandidType, Deserialize, Debug)]
+    pub struct GetAddressRequest {
+        pub network: BitcoinNetwork,
+        pub address_type: BitcoinAddressType,
+    }
+
+    #[derive(CandidType, Deserialize, Debug)]
+    pub struct GetAddressResponse {
+        pub address: String,
+    }
+
+    #[derive(CandidType, Deserialize, Debug)]
+    pub enum GetAddressError {
+        InternalError { msg: String },
+    }
+
+    #[derive(CandidType, Deserialize, Debug)]
+    pub struct GetBalanceRequest {
+        pub network: BitcoinNetwork,
+        pub address_type: BitcoinAddressType,
+    }
+
+
+    #[derive(CandidType, Deserialize, Debug)]
+    pub struct GetBalanceResponse {
+        pub balance: Nat,
+    }
+
+    #[derive(CandidType, Deserialize, Debug)]
+    pub enum GetBalanceError {
+        InternalError { msg: String },
+    }
+}

--- a/src/signer/api/src/types.rs
+++ b/src/signer/api/src/types.rs
@@ -74,7 +74,6 @@ pub mod bitcoin {
         pub address_type: BitcoinAddressType,
     }
 
-
     #[derive(CandidType, Deserialize, Debug)]
     pub struct GetBalanceResponse {
         pub balance: Nat,

--- a/src/signer/api/src/types.rs
+++ b/src/signer/api/src/types.rs
@@ -44,7 +44,7 @@ pub mod transaction {
 }
 
 pub mod bitcoin {
-    use candid::{CandidType, Deserialize, Nat};
+    use candid::{CandidType, Deserialize};
     use ic_cdk::api::management_canister::bitcoin::BitcoinNetwork;
 
     #[derive(CandidType, Deserialize, Debug)]
@@ -76,7 +76,7 @@ pub mod bitcoin {
 
     #[derive(CandidType, Deserialize, Debug)]
     pub struct GetBalanceResponse {
-        pub balance: Nat,
+        pub balance: u64,
     }
 
     #[derive(CandidType, Deserialize, Debug)]

--- a/src/signer/canister/signer.did
+++ b/src/signer/canister/signer.did
@@ -31,7 +31,7 @@ type GetAddressRequest = record {
   address_type : BitcoinAddressType;
 };
 type GetAddressResponse = record { address : text };
-type GetBalanceResponse = record { balance : nat };
+type GetBalanceResponse = record { balance : nat64 };
 type HttpRequest = record {
   url : text;
   method : text;

--- a/src/signer/canister/signer.did
+++ b/src/signer/canister/signer.did
@@ -1,4 +1,5 @@
 type Arg = variant { Upgrade; Init : InitArg };
+type BitcoinAddressType = variant { P2WPKH };
 type BitcoinNetwork = variant { mainnet; regtest; testnet };
 type CanisterStatusResultV2 = record {
   controller : principal;
@@ -24,6 +25,13 @@ type DefiniteCanisterSettingsArgs = record {
   memory_allocation : nat;
   compute_allocation : nat;
 };
+type GetAddressError = variant { InternalError : record { msg : text } };
+type GetAddressRequest = record {
+  network : BitcoinNetwork;
+  address_type : BitcoinAddressType;
+};
+type GetAddressResponse = record { address : text };
+type GetBalanceResponse = record { balance : nat };
 type HttpRequest = record {
   url : text;
   method : text;
@@ -40,6 +48,8 @@ type InitArg = record {
   ic_root_key_der : opt blob;
   cycles_ledger : opt principal;
 };
+type Result = variant { Ok : GetAddressResponse; Err : GetAddressError };
+type Result_1 = variant { Ok : GetBalanceResponse; Err : GetAddressError };
 type SignRequest = record {
   to : text;
   gas : nat;
@@ -51,8 +61,8 @@ type SignRequest = record {
   nonce : nat;
 };
 service : (Arg) -> {
-  caller_btc_address : (BitcoinNetwork) -> (text);
-  caller_btc_balance : (BitcoinNetwork) -> (nat64);
+  btc_caller_address : (GetAddressRequest) -> (Result);
+  btc_caller_balance : (GetAddressRequest) -> (Result_1);
   caller_eth_address : () -> (text);
   config : () -> (Config) query;
   eth_address_of : (principal) -> (text);

--- a/src/signer/canister/src/lib.rs
+++ b/src/signer/canister/src/lib.rs
@@ -165,7 +165,7 @@ async fn btc_caller_balance(
                 .map_err(|msg| GetBalanceError::InternalError { msg })?;
 
             Ok(GetBalanceResponse {
-                balance: balance.into(),
+                balance,
             })
         }
     }

--- a/src/signer/canister/src/lib.rs
+++ b/src/signer/canister/src/lib.rs
@@ -133,7 +133,7 @@ async fn sign_prehash(prehash: String) -> String {
 
 /// Returns the Bitcoin address of the caller.
 #[update(guard = "caller_is_not_anonymous")]
-async fn caller_btc_address(
+async fn btc_caller_address(
     params: GetAddressRequest,
 ) -> Result<GetAddressResponse, GetAddressError> {
     match params.address_type {
@@ -150,7 +150,7 @@ async fn caller_btc_address(
 
 /// Returns the Bitcoin balance of the caller's address.
 #[update(guard = "caller_is_not_anonymous")]
-async fn caller_btc_balance(
+async fn btc_caller_balance(
     params: GetBalanceRequest,
 ) -> Result<GetBalanceResponse, GetBalanceError> {
     match params.address_type {

--- a/src/signer/canister/src/lib.rs
+++ b/src/signer/canister/src/lib.rs
@@ -164,9 +164,7 @@ async fn btc_caller_balance(
                 .await
                 .map_err(|msg| GetBalanceError::InternalError { msg })?;
 
-            Ok(GetBalanceResponse {
-                balance,
-            })
+            Ok(GetBalanceResponse { balance })
         }
     }
 }

--- a/src/signer/canister/src/lib.rs
+++ b/src/signer/canister/src/lib.rs
@@ -9,9 +9,11 @@ use ic_chain_fusion_signer_api::types::bitcoin::GetAddressError;
 use ic_chain_fusion_signer_api::types::bitcoin::GetAddressRequest;
 use ic_chain_fusion_signer_api::types::bitcoin::GetAddressResponse;
 use ic_chain_fusion_signer_api::types::bitcoin::GetBalanceRequest;
+use ic_chain_fusion_signer_api::types::bitcoin::{
+    BitcoinAddressType, GetBalanceError, GetBalanceResponse,
+};
 use ic_chain_fusion_signer_api::types::transaction::SignRequest;
 use ic_chain_fusion_signer_api::types::{Arg, Config};
-use ic_chain_fusion_signer_api::types::bitcoin::{BitcoinAddressType, GetBalanceError, GetBalanceResponse};
 use serde_bytes::ByteBuf;
 use sign::bitcoin::{bitcoin_api, bitcoin_utils};
 use sign::eth;
@@ -131,17 +133,15 @@ async fn sign_prehash(prehash: String) -> String {
 
 /// Returns the Bitcoin address of the caller.
 #[update(guard = "caller_is_not_anonymous")]
-async fn caller_btc_address(params: GetAddressRequest) -> Result<GetAddressResponse, GetAddressError> {
+async fn caller_btc_address(
+    params: GetAddressRequest,
+) -> Result<GetAddressResponse, GetAddressError> {
     match params.address_type {
         BitcoinAddressType::P2WPKH => {
-            let address = bitcoin_utils::principal_to_p2wpkh_address(
-                params.network,
-                &ic_cdk::caller(),
-            )
-            .await
-            .map_err(|msg| GetAddressError::InternalError { 
-                msg,
-            })?;
+            let address =
+                bitcoin_utils::principal_to_p2wpkh_address(params.network, &ic_cdk::caller())
+                    .await
+                    .map_err(|msg| GetAddressError::InternalError { msg })?;
 
             Ok(GetAddressResponse { address })
         }
@@ -150,23 +150,23 @@ async fn caller_btc_address(params: GetAddressRequest) -> Result<GetAddressRespo
 
 /// Returns the Bitcoin balance of the caller's address.
 #[update(guard = "caller_is_not_anonymous")]
-async fn caller_btc_balance(params: GetBalanceRequest) -> Result<GetBalanceResponse, GetBalanceError> {
+async fn caller_btc_balance(
+    params: GetBalanceRequest,
+) -> Result<GetBalanceResponse, GetBalanceError> {
     match params.address_type {
         BitcoinAddressType::P2WPKH => {
-            let address = bitcoin_utils::principal_to_p2wpkh_address(
-                params.network,
-                &ic_cdk::caller(),
-            )
-            .await
-            .map_err(|msg| GetBalanceError::InternalError { 
-                msg,
-            })?;
+            let address =
+                bitcoin_utils::principal_to_p2wpkh_address(params.network, &ic_cdk::caller())
+                    .await
+                    .map_err(|msg| GetBalanceError::InternalError { msg })?;
 
             let balance = bitcoin_api::get_balance(params.network, address)
                 .await
                 .map_err(|msg| GetBalanceError::InternalError { msg })?;
 
-            Ok(GetBalanceResponse { balance: balance.into() })
+            Ok(GetBalanceResponse {
+                balance: balance.into(),
+            })
         }
     }
 }

--- a/src/signer/canister/src/sign/bitcoin/bitcoin_api.rs
+++ b/src/signer/canister/src/sign/bitcoin/bitcoin_api.rs
@@ -12,9 +12,9 @@ pub async fn get_balance(network: BitcoinNetwork, address: String) -> Result<u64
         address,
         network,
         min_confirmations,
-    }).await
+    })
+    .await
     .map_err(|err| err.1)?;
 
     Ok(balance_res.0)
-
 }

--- a/src/signer/canister/src/sign/bitcoin/bitcoin_api.rs
+++ b/src/signer/canister/src/sign/bitcoin/bitcoin_api.rs
@@ -6,14 +6,15 @@ use ic_cdk::api::management_canister::bitcoin::{
 ///
 /// Relies on the `bitcoin_get_balance` endpoint.
 /// See [Bitcoin API](https://internetcomputer.org/docs/current/references/ic-interface-spec/#ic-bitcoin_get_balance)
-pub async fn get_balance(network: BitcoinNetwork, address: String) -> u64 {
+pub async fn get_balance(network: BitcoinNetwork, address: String) -> Result<u64, String> {
     let min_confirmations = None;
     let balance_res = bitcoin_get_balance(GetBalanceRequest {
         address,
         network,
         min_confirmations,
-    })
-    .await;
+    }).await
+    .map_err(|err| err.1)?;
 
-    balance_res.unwrap().0
+    Ok(balance_res.0)
+
 }

--- a/src/signer/canister/src/sign/bitcoin/bitcoin_utils.rs
+++ b/src/signer/canister/src/sign/bitcoin/bitcoin_utils.rs
@@ -19,7 +19,8 @@ async fn ecdsa_pubkey_of(principal: &Principal) -> Result<Vec<u8>, String> {
             name,
         },
     })
-    .await {
+    .await
+    {
         Ok(key.public_key)
     } else {
         Err("Failed to get ecdsa public key".to_string())
@@ -35,15 +36,15 @@ fn transform_network(network: BitcoinNetwork) -> Network {
 }
 
 /// Converts a public key to a P2PKH address.
-pub async fn principal_to_p2wpkh_address(network: BitcoinNetwork, principal: &Principal) -> Result<String, String> {
-    let ecdsa_pubkey = ecdsa_pubkey_of(&principal).await
+pub async fn principal_to_p2wpkh_address(
+    network: BitcoinNetwork,
+    principal: &Principal,
+) -> Result<String, String> {
+    let ecdsa_pubkey = ecdsa_pubkey_of(&principal)
+        .await
         .map_err(|_| "Error getting ECDSA public key".to_string())?;
     if let Ok(compressed_public_key) = CompressedPublicKey::from_slice(&ecdsa_pubkey) {
-        Ok(Address::p2wpkh(
-            &compressed_public_key,
-            transform_network(network),
-        )
-        .to_string())
+        Ok(Address::p2wpkh(&compressed_public_key, transform_network(network)).to_string())
     } else {
         Err("Error getting P2WPKH from public key".to_string())
     }

--- a/src/signer/canister/src/sign/bitcoin/bitcoin_utils.rs
+++ b/src/signer/canister/src/sign/bitcoin/bitcoin_utils.rs
@@ -1,7 +1,7 @@
 //! Code for signing Bitcoin transactions.
 use crate::derivation_path::Schema;
 use crate::state::read_config;
-use bitcoin::{Address, Network, PublicKey};
+use bitcoin::{Address, CompressedPublicKey, Network};
 use candid::Principal;
 use ic_cdk::api::management_canister::bitcoin::BitcoinNetwork;
 use ic_cdk::api::management_canister::ecdsa::{
@@ -9,9 +9,9 @@ use ic_cdk::api::management_canister::ecdsa::{
 };
 
 /// Computes the public key of the specified principal.
-pub async fn ecdsa_pubkey_of(principal: &Principal) -> Vec<u8> {
+async fn ecdsa_pubkey_of(principal: &Principal) -> Result<Vec<u8>, String> {
     let name = read_config(|s| s.ecdsa_key_name.clone());
-    let (key,) = ecdsa_public_key(EcdsaPublicKeyArgument {
+    if let Ok((key,)) = ecdsa_public_key(EcdsaPublicKeyArgument {
         canister_id: None,
         derivation_path: Schema::Btc.derivation_path(principal),
         key_id: EcdsaKeyId {
@@ -19,9 +19,11 @@ pub async fn ecdsa_pubkey_of(principal: &Principal) -> Vec<u8> {
             name,
         },
     })
-    .await
-    .expect("failed to get public key");
-    key.public_key
+    .await {
+        Ok(key.public_key)
+    } else {
+        Err("Failed to get ecdsa public key".to_string())
+    }
 }
 
 fn transform_network(network: BitcoinNetwork) -> Network {
@@ -33,11 +35,16 @@ fn transform_network(network: BitcoinNetwork) -> Network {
 }
 
 /// Converts a public key to a P2PKH address.
-/// Reference: [IC Bitcoin Documentation](https://internetcomputer.org/docs/current/developer-docs/multi-chain/bitcoin/using-btc/generate-addresses#generating-addresses-with-threshold-ecdsa)
-pub fn public_key_to_p2pkh_address(network: BitcoinNetwork, public_key: &[u8]) -> String {
-    Address::p2pkh(
-        PublicKey::from_slice(public_key).expect("failed to parse public key"),
-        transform_network(network),
-    )
-    .to_string()
+pub async fn principal_to_p2wpkh_address(network: BitcoinNetwork, principal: &Principal) -> Result<String, String> {
+    let ecdsa_pubkey = ecdsa_pubkey_of(&principal).await
+        .map_err(|_| "Error getting ECDSA public key".to_string())?;
+    if let Ok(compressed_public_key) = CompressedPublicKey::from_slice(&ecdsa_pubkey) {
+        Ok(Address::p2wpkh(
+            &compressed_public_key,
+            transform_network(network),
+        )
+        .to_string())
+    } else {
+        Err("Error getting P2WPKH from public key".to_string())
+    }
 }

--- a/src/signer/canister/src/sign/bitcoin/bitcoin_utils.rs
+++ b/src/signer/canister/src/sign/bitcoin/bitcoin_utils.rs
@@ -40,7 +40,7 @@ pub async fn principal_to_p2wpkh_address(
     network: BitcoinNetwork,
     principal: &Principal,
 ) -> Result<String, String> {
-    let ecdsa_pubkey = ecdsa_pubkey_of(&principal)
+    let ecdsa_pubkey = ecdsa_pubkey_of(principal)
         .await
         .map_err(|_| "Error getting ECDSA public key".to_string())?;
     if let Ok(compressed_public_key) = CompressedPublicKey::from_slice(&ecdsa_pubkey) {

--- a/src/signer/canister/tests/it/address.rs
+++ b/src/signer/canister/tests/it/address.rs
@@ -1,9 +1,10 @@
 use crate::utils::mock::{
-    CALLER, CALLER_BTC_ADDRESS_MAINNET, CALLER_BTC_ADDRESS_TESTNET, CALLER_ETH_ADDRESS,
+    CALLER, CALLER_BTC_ADDRESS_MAINNET, CALLER_BTC_ADDRESS_REGTEST, CALLER_BTC_ADDRESS_TESTNET, CALLER_ETH_ADDRESS,
 };
 use crate::utils::pocketic::{setup, PicCanisterTrait};
 use candid::Principal;
 use ic_cdk::api::management_canister::bitcoin::BitcoinNetwork;
+use ic_chain_fusion_signer_api::types::bitcoin::{BitcoinAddressType, GetAddressError, GetAddressRequest, GetAddressResponse};
 
 #[test]
 fn test_caller_eth_address() {
@@ -64,12 +65,17 @@ fn test_caller_btc_address_mainnet() {
 
     let caller = Principal::from_text(CALLER).unwrap();
     let network = BitcoinNetwork::Mainnet;
+    let params = GetAddressRequest {
+        network,
+        address_type: BitcoinAddressType::P2WPKH,
+    };
 
-    let address = pic_setup
-        .update::<String>(caller, "caller_btc_address", network)
-        .expect("Failed to call mainnet btc address.");
+    let address_response = pic_setup
+        .update::<Result<GetAddressResponse, GetAddressError>>(caller, "caller_btc_address", params)
+        .expect("Failed to call testnet btc address.")
+        .expect("Failed to get successful response");
 
-    assert_eq!(address, CALLER_BTC_ADDRESS_MAINNET.to_string());
+    assert_eq!(address_response.address, CALLER_BTC_ADDRESS_MAINNET.to_string());
 }
 
 #[test]
@@ -78,20 +84,48 @@ fn test_caller_btc_address_testnet() {
 
     let caller = Principal::from_text(CALLER).unwrap();
     let network = BitcoinNetwork::Testnet;
+    let params = GetAddressRequest {
+        network,
+        address_type: BitcoinAddressType::P2WPKH,
+    };
 
-    let address = pic_setup
-        .update::<String>(caller, "caller_btc_address", network)
-        .expect("Failed to call testnet btc address.");
+    let address_response = pic_setup
+        .update::<Result<GetAddressResponse, GetAddressError>>(caller, "caller_btc_address", params)
+        .expect("Failed to call testnet btc address.")
+        .expect("Failed to get successful response");
 
-    assert_eq!(address, CALLER_BTC_ADDRESS_TESTNET.to_string());
+    assert_eq!(address_response.address, CALLER_BTC_ADDRESS_TESTNET.to_string());
+}
+
+#[test]
+fn test_caller_btc_address_regtest() {
+    let pic_setup = setup();
+
+    let caller = Principal::from_text(CALLER).unwrap();
+    let network = BitcoinNetwork::Regtest;
+    let params = GetAddressRequest {
+        network,
+        address_type: BitcoinAddressType::P2WPKH,
+    };
+
+    let address_response = pic_setup
+        .update::<Result<GetAddressResponse, GetAddressError>>(caller, "caller_btc_address", params)
+        .expect("Failed to call testnet btc address.")
+        .expect("Failed to get successful response");
+
+    assert_eq!(address_response.address, CALLER_BTC_ADDRESS_REGTEST.to_string());
 }
 
 #[test]
 fn test_anonymous_cannot_call_btc_address() {
     let pic_setup = setup();
     let network = BitcoinNetwork::Testnet;
+    let params = GetAddressRequest {
+        network,
+        address_type: BitcoinAddressType::P2WPKH,
+    };
 
-    let address = pic_setup.update::<String>(Principal::anonymous(), "caller_btc_address", network);
+    let address = pic_setup.update::<String>(Principal::anonymous(), "caller_btc_address", params);
 
     assert!(address.is_err());
     assert_eq!(
@@ -101,20 +135,28 @@ fn test_anonymous_cannot_call_btc_address() {
 }
 
 #[test]
-fn test_testnet_btc_address_is_same_as_regtest() {
+fn test_testnet_btc_address_is_not_same_as_regtest() {
     let pic_setup = setup();
 
     let caller = Principal::from_text(CALLER).unwrap();
-    let testnet = BitcoinNetwork::Testnet;
-    let regtest = BitcoinNetwork::Regtest;
+    let params_testnet = GetAddressRequest {
+        network: BitcoinNetwork::Testnet,
+        address_type: BitcoinAddressType::P2WPKH,
+    };
+    let params_regtest = GetAddressRequest {
+        network: BitcoinNetwork::Regtest,
+        address_type: BitcoinAddressType::P2WPKH,
+    };
 
-    let address_testnet = pic_setup
-        .update::<String>(caller, "caller_btc_address", testnet)
-        .expect("Failed to call testnet btc address.");
+    let address_response_testnet = pic_setup
+        .update::<Result<GetAddressResponse, GetAddressError>>(caller, "caller_btc_address", params_testnet)
+        .expect("Failed to call testnet btc address.")
+        .expect("Failed to get successful response");
 
-    let address_regtest = pic_setup
-        .update::<String>(caller, "caller_btc_address", regtest)
-        .expect("Failed to call regtest btc address.");
+        let address_response_regtest = pic_setup
+        .update::<Result<GetAddressResponse, GetAddressError>>(caller, "caller_btc_address", params_regtest)
+        .expect("Failed to call testnet btc address.")
+        .expect("Failed to get successful response");
 
-    assert_eq!(address_testnet, address_regtest);
+    assert_ne!(address_response_testnet.address, address_response_regtest.address);
 }

--- a/src/signer/canister/tests/it/address.rs
+++ b/src/signer/canister/tests/it/address.rs
@@ -1,10 +1,13 @@
 use crate::utils::mock::{
-    CALLER, CALLER_BTC_ADDRESS_MAINNET, CALLER_BTC_ADDRESS_REGTEST, CALLER_BTC_ADDRESS_TESTNET, CALLER_ETH_ADDRESS,
+    CALLER, CALLER_BTC_ADDRESS_MAINNET, CALLER_BTC_ADDRESS_REGTEST, CALLER_BTC_ADDRESS_TESTNET,
+    CALLER_ETH_ADDRESS,
 };
 use crate::utils::pocketic::{setup, PicCanisterTrait};
 use candid::Principal;
 use ic_cdk::api::management_canister::bitcoin::BitcoinNetwork;
-use ic_chain_fusion_signer_api::types::bitcoin::{BitcoinAddressType, GetAddressError, GetAddressRequest, GetAddressResponse};
+use ic_chain_fusion_signer_api::types::bitcoin::{
+    BitcoinAddressType, GetAddressError, GetAddressRequest, GetAddressResponse,
+};
 
 #[test]
 fn test_caller_eth_address() {
@@ -75,7 +78,10 @@ fn test_caller_btc_address_mainnet() {
         .expect("Failed to call testnet btc address.")
         .expect("Failed to get successful response");
 
-    assert_eq!(address_response.address, CALLER_BTC_ADDRESS_MAINNET.to_string());
+    assert_eq!(
+        address_response.address,
+        CALLER_BTC_ADDRESS_MAINNET.to_string()
+    );
 }
 
 #[test]
@@ -94,7 +100,10 @@ fn test_caller_btc_address_testnet() {
         .expect("Failed to call testnet btc address.")
         .expect("Failed to get successful response");
 
-    assert_eq!(address_response.address, CALLER_BTC_ADDRESS_TESTNET.to_string());
+    assert_eq!(
+        address_response.address,
+        CALLER_BTC_ADDRESS_TESTNET.to_string()
+    );
 }
 
 #[test]
@@ -113,7 +122,10 @@ fn test_caller_btc_address_regtest() {
         .expect("Failed to call testnet btc address.")
         .expect("Failed to get successful response");
 
-    assert_eq!(address_response.address, CALLER_BTC_ADDRESS_REGTEST.to_string());
+    assert_eq!(
+        address_response.address,
+        CALLER_BTC_ADDRESS_REGTEST.to_string()
+    );
 }
 
 #[test]
@@ -149,14 +161,25 @@ fn test_testnet_btc_address_is_not_same_as_regtest() {
     };
 
     let address_response_testnet = pic_setup
-        .update::<Result<GetAddressResponse, GetAddressError>>(caller, "caller_btc_address", params_testnet)
+        .update::<Result<GetAddressResponse, GetAddressError>>(
+            caller,
+            "caller_btc_address",
+            params_testnet,
+        )
         .expect("Failed to call testnet btc address.")
         .expect("Failed to get successful response");
 
-        let address_response_regtest = pic_setup
-        .update::<Result<GetAddressResponse, GetAddressError>>(caller, "caller_btc_address", params_regtest)
+    let address_response_regtest = pic_setup
+        .update::<Result<GetAddressResponse, GetAddressError>>(
+            caller,
+            "caller_btc_address",
+            params_regtest,
+        )
         .expect("Failed to call testnet btc address.")
         .expect("Failed to get successful response");
 
-    assert_ne!(address_response_testnet.address, address_response_regtest.address);
+    assert_ne!(
+        address_response_testnet.address,
+        address_response_regtest.address
+    );
 }

--- a/src/signer/canister/tests/it/address.rs
+++ b/src/signer/canister/tests/it/address.rs
@@ -74,7 +74,7 @@ fn test_caller_btc_address_mainnet() {
     };
 
     let address_response = pic_setup
-        .update::<Result<GetAddressResponse, GetAddressError>>(caller, "caller_btc_address", params)
+        .update::<Result<GetAddressResponse, GetAddressError>>(caller, "btc_caller_address", params)
         .expect("Failed to call testnet btc address.")
         .expect("Failed to get successful response");
 
@@ -96,7 +96,7 @@ fn test_caller_btc_address_testnet() {
     };
 
     let address_response = pic_setup
-        .update::<Result<GetAddressResponse, GetAddressError>>(caller, "caller_btc_address", params)
+        .update::<Result<GetAddressResponse, GetAddressError>>(caller, "btc_caller_address", params)
         .expect("Failed to call testnet btc address.")
         .expect("Failed to get successful response");
 
@@ -118,7 +118,7 @@ fn test_caller_btc_address_regtest() {
     };
 
     let address_response = pic_setup
-        .update::<Result<GetAddressResponse, GetAddressError>>(caller, "caller_btc_address", params)
+        .update::<Result<GetAddressResponse, GetAddressError>>(caller, "btc_caller_address", params)
         .expect("Failed to call testnet btc address.")
         .expect("Failed to get successful response");
 
@@ -137,7 +137,7 @@ fn test_anonymous_cannot_call_btc_address() {
         address_type: BitcoinAddressType::P2WPKH,
     };
 
-    let address = pic_setup.update::<String>(Principal::anonymous(), "caller_btc_address", params);
+    let address = pic_setup.update::<String>(Principal::anonymous(), "btc_caller_address", params);
 
     assert!(address.is_err());
     assert_eq!(
@@ -163,7 +163,7 @@ fn test_testnet_btc_address_is_not_same_as_regtest() {
     let address_response_testnet = pic_setup
         .update::<Result<GetAddressResponse, GetAddressError>>(
             caller,
-            "caller_btc_address",
+            "btc_caller_address",
             params_testnet,
         )
         .expect("Failed to call testnet btc address.")
@@ -172,7 +172,7 @@ fn test_testnet_btc_address_is_not_same_as_regtest() {
     let address_response_regtest = pic_setup
         .update::<Result<GetAddressResponse, GetAddressError>>(
             caller,
-            "caller_btc_address",
+            "btc_caller_address",
             params_regtest,
         )
         .expect("Failed to call testnet btc address.")

--- a/src/signer/canister/tests/it/bitcoin.rs
+++ b/src/signer/canister/tests/it/bitcoin.rs
@@ -1,6 +1,6 @@
 use crate::utils::mock::CALLER;
 use crate::utils::pocketic::{setup, PicCanisterTrait};
-use candid::{Nat, Principal};
+use candid::Principal;
 use ic_cdk::api::management_canister::bitcoin::BitcoinNetwork;
 use ic_chain_fusion_signer_api::types::bitcoin::{
     BitcoinAddressType, GetBalanceError, GetBalanceRequest, GetBalanceResponse,
@@ -18,9 +18,9 @@ fn test_caller_btc_balance() {
     };
 
     let balance_response = pic_setup
-        .update::<Result<GetBalanceResponse, GetBalanceError>>(caller, "caller_btc_balance", params)
+        .update::<Result<GetBalanceResponse, GetBalanceError>>(caller, "btc_caller_balance", params)
         .expect("Failed to call testnet btc balance.")
         .expect("Failed to get successul balance response");
 
-    assert_eq!(balance_response.balance, Nat::from(0u128));
+    assert_eq!(balance_response.balance, 0u64);
 }

--- a/src/signer/canister/tests/it/bitcoin.rs
+++ b/src/signer/canister/tests/it/bitcoin.rs
@@ -1,7 +1,8 @@
 use crate::utils::mock::CALLER;
 use crate::utils::pocketic::{setup, PicCanisterTrait};
-use candid::Principal;
+use candid::{Nat, Principal};
 use ic_cdk::api::management_canister::bitcoin::BitcoinNetwork;
+use ic_chain_fusion_signer_api::types::bitcoin::{BitcoinAddressType, GetBalanceError, GetBalanceResponse, GetBalanceRequest};
 
 #[test]
 fn test_caller_btc_balance() {
@@ -9,10 +10,15 @@ fn test_caller_btc_balance() {
 
     let caller = Principal::from_text(CALLER).unwrap();
     let network = BitcoinNetwork::Regtest;
+    let params = GetBalanceRequest {
+        network,
+        address_type: BitcoinAddressType::P2WPKH,
+    };
 
-    let balance = pic_setup
-        .update::<u64>(caller, "caller_btc_balance", network)
-        .expect("Failed to call testnet btc balance.");
+    let balance_response = pic_setup
+        .update::<Result<GetBalanceResponse, GetBalanceError>>(caller, "caller_btc_balance", params)
+        .expect("Failed to call testnet btc balance.")
+        .expect("Failed to get successul balance response");
 
-    assert_eq!(balance, 0);
+    assert_eq!(balance_response.balance, Nat::from(0u128));
 }

--- a/src/signer/canister/tests/it/bitcoin.rs
+++ b/src/signer/canister/tests/it/bitcoin.rs
@@ -2,7 +2,9 @@ use crate::utils::mock::CALLER;
 use crate::utils::pocketic::{setup, PicCanisterTrait};
 use candid::{Nat, Principal};
 use ic_cdk::api::management_canister::bitcoin::BitcoinNetwork;
-use ic_chain_fusion_signer_api::types::bitcoin::{BitcoinAddressType, GetBalanceError, GetBalanceResponse, GetBalanceRequest};
+use ic_chain_fusion_signer_api::types::bitcoin::{
+    BitcoinAddressType, GetBalanceError, GetBalanceRequest, GetBalanceResponse,
+};
 
 #[test]
 fn test_caller_btc_balance() {

--- a/src/signer/canister/tests/it/utils/mock.rs
+++ b/src/signer/canister/tests/it/utils/mock.rs
@@ -1,7 +1,8 @@
 pub const CALLER: &str = "xzg7k-thc6c-idntg-knmtz-2fbhh-utt3e-snqw6-5xph3-54pbp-7axl5-tae";
 pub const CALLER_ETH_ADDRESS: &str = "0x5e9F1cAF942aa8Ee887B75f5A6bCCaf4B1024248";
-pub const CALLER_BTC_ADDRESS_MAINNET: &str = "1DjBJh38CUPBvK1vCi5sKfRiBWFDbg5rLB"; // Depends on pocket-ic version.
-pub const CALLER_BTC_ADDRESS_TESTNET: &str = "mtF8bk871VpShRVXvH4F9ae33VqvWWXhzf";
+pub const CALLER_BTC_ADDRESS_MAINNET: &str = "bc1q3wdefl87eajdsutfgjxxrhqm7dcthgsdvx3yvr"; // Depends on pocket-ic version.
+pub const CALLER_BTC_ADDRESS_TESTNET: &str = "tb1q3wdefl87eajdsutfgjxxrhqm7dcthgsdxq2hhs";
+pub const CALLER_BTC_ADDRESS_REGTEST: &str = "bcrt1q3wdefl87eajdsutfgjxxrhqm7dcthgsdyfn6qe";
 
 /// An admin user.  Typically, controls the backend canister.
 pub const CONTROLLER: &str = "l3lfs-gak7g-xrbil-j4v4h-aztjn-4jyki-wprso-m27h3-ibcl3-2cwuz-oqe";


### PR DESCRIPTION
# Motivation

Use P2WPKH instead of P2PKH and prepare the address and balance endpoints for bitcoin for frontwards compatibility by introducing request and response types.

# Changes

* New request and response types for getting the btc address and balance.
* Change the bitcoin utils to return a Result instead of failing.
* Change `caller_btc_address` and `caller_btc_balance` to use params and return Result.
* Change `caller_btc_address` and `caller_btc_balance` to work only for P2WPKH address type.
* Remove `public_key_to_p2pkh_address` and implement `principal_to_p2wpkh_address` instead.

# Tests

* Change the test to use new request and response types.
* Change expected addresses because they are not the same with P2WPKH type.
