### PR TITLE
fix(signer): Update signer candid path

### DIFF
--- a/dfx.json
+++ b/dfx.json
@@ -4,7 +4,7 @@
 		"signer": {
 			"type": "custom",
 			"build": "scripts/build.signer.sh",
-			"candid": "src/signer/signer.did",
+			"candid": "src/signer/canister/signer.did",
 			"wasm": "out/signer.wasm.gz",
 			"init_arg_file": "out/signer.args.did"
 		},

--- a/scripts/did.sh
+++ b/scripts/did.sh
@@ -2,15 +2,15 @@
 
 function generate_did() {
   local canister=$1
-  canister_root="src/$canister"
+  local candid_file="$(canister="$canister" jq -r .canisters[env.canister].candid dfx.json)"
 
   test -e "target/wasm32-unknown-unknown/release/$canister.wasm" ||
-    cargo build --manifest-path="$canister_root/Cargo.toml" \
+    cargo build \
       --target wasm32-unknown-unknown \
       --release --package "$canister"
 
   # cargo install candid-extractor
-  candid-extractor "target/wasm32-unknown-unknown/release/${canister//-/_}.wasm" >"$canister_root/$canister.did"
+  candid-extractor "target/wasm32-unknown-unknown/release/${canister//-/_}.wasm" >"$candid_file"
 }
 
 CANISTERS=signer


### PR DESCRIPTION
# Motivation
In 2d8f80cb2c47a4b11793e6a29f85ed7aeffc05a0 the signer canister source code was moved.  But `dfx.json` was not updated with the new canister path.

# Changes
- Update the candid path in `dfx.json`
- Update the .did file generation command to use the new location.

# Tests

<!-- Please provide any information or screenshots about the tests that have been done -->
