### PR TITLE
feat(signer): Add cycles ledger as an install argument

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1089,6 +1089,7 @@ dependencies = [
  "ic-cdk 0.16.0",
  "ic-cdk-macros 0.16.0",
  "ic-metrics-encoder",
+ "ic-papi-api",
  "serde",
  "serde_bytes",
  "strum 0.26.3",

--- a/scripts/build.signer.args.sh
+++ b/scripts/build.signer.args.sh
@@ -57,6 +57,7 @@ cat <<EOF >"$ARG_FILE"
     Init = record {
          ecdsa_key_name = "$ECDSA_KEY_NAME";
          ic_root_key_der = $ic_root_key_der;
+         cycles_ledger = opt principal "$CANISTER_ID_CYCLES_LEDGER";
      }
   })
 EOF

--- a/src/signer/api/Cargo.toml
+++ b/src/signer/api/Cargo.toml
@@ -9,6 +9,7 @@ ic-canister-sig-creation = { workspace = true }
 ic-cdk = { workspace = true }
 ic-cdk-macros = { workspace = true }
 ic-metrics-encoder = { workspace = true }
+ic-papi-api = { workspace = true }
 serde = { workspace = true }
 serde_bytes = { workspace = true }
 strum = { workspace = true }

--- a/src/signer/api/src/impls.rs
+++ b/src/signer/api/src/impls.rs
@@ -10,6 +10,7 @@ impl From<InitArg> for Config {
         let InitArg {
             ecdsa_key_name,
             ic_root_key_der,
+            cycles_ledger,
         } = arg;
         let ic_root_key_raw = match extract_raw_root_pk_from_der(
             &ic_root_key_der.unwrap_or_else(|| IC_ROOT_PK_DER.to_vec()),
@@ -17,9 +18,12 @@ impl From<InitArg> for Config {
             Ok(root_key) => root_key,
             Err(msg) => panic!("{}", format!("Error parsing root key: {msg}")),
         };
+        let cycles_ledger =
+            cycles_ledger.unwrap_or_else(ic_papi_api::cycles::cycles_ledger_canister_id);
         Config {
             ecdsa_key_name,
             ic_root_key_raw: Some(ic_root_key_raw),
+            cycles_ledger,
         }
     }
 }

--- a/src/signer/api/src/types.rs
+++ b/src/signer/api/src/types.rs
@@ -1,4 +1,4 @@
-use candid::{CandidType, Deserialize};
+use candid::{CandidType, Deserialize, Principal};
 use std::fmt::Debug;
 
 pub type Timestamp = u64;
@@ -8,6 +8,8 @@ pub struct InitArg {
     pub ecdsa_key_name: String,
     /// Root of trust for checking canister signatures.
     pub ic_root_key_der: Option<Vec<u8>>,
+    /// Payment canister ID.
+    pub cycles_ledger: Option<Principal>,
 }
 
 #[derive(CandidType, Deserialize, Clone, Debug, Eq, PartialEq)]
@@ -21,6 +23,8 @@ pub struct Config {
     pub ecdsa_key_name: String,
     /// Root of trust for checking canister signatures.
     pub ic_root_key_raw: Option<Vec<u8>>,
+    /// Payment canister ID.
+    pub cycles_ledger: Principal,
 }
 
 pub mod transaction {

--- a/src/signer/canister/signer.did
+++ b/src/signer/canister/signer.did
@@ -12,7 +12,11 @@ type CanisterStatusResultV2 = record {
   module_hash : opt blob;
 };
 type CanisterStatusType = variant { stopped; stopping; running };
-type Config = record { ecdsa_key_name : text; ic_root_key_raw : opt blob };
+type Config = record {
+  ecdsa_key_name : text;
+  ic_root_key_raw : opt blob;
+  cycles_ledger : principal;
+};
 type DefiniteCanisterSettingsArgs = record {
   controller : principal;
   freezing_threshold : nat;
@@ -31,7 +35,11 @@ type HttpResponse = record {
   headers : vec record { text; text };
   status_code : nat16;
 };
-type InitArg = record { ecdsa_key_name : text; ic_root_key_der : opt blob };
+type InitArg = record {
+  ecdsa_key_name : text;
+  ic_root_key_der : opt blob;
+  cycles_ledger : opt principal;
+};
 type SignRequest = record {
   to : text;
   gas : nat;

--- a/src/signer/canister/tests/it/utils/pocketic.rs
+++ b/src/signer/canister/tests/it/utils/pocketic.rs
@@ -150,6 +150,7 @@ impl BackendBuilder {
         Arg::Init(InitArg {
             ecdsa_key_name: format!("test_key_1"),
             ic_root_key_der: None,
+            cycles_ledger: None,
         })
     }
     /// The default controllers of the backend canister.


### PR DESCRIPTION
# Motivation
We now take payment for API calls.  In mainnet the cycles ledger canister ID is fixed, but in test environments is is helpful, and sometimes necessary, to use a different canister ID.

# Changes
- Add an optional ledger canister ID to the install arguments.  If not provided, it falls back to the default.

# Tests
See CI