### PR TITLE
fix(devops): Specify II and cycles ledger canister IDs for staging

### DIFF
--- a/dfx.json
+++ b/dfx.json
@@ -39,6 +39,7 @@
 			"init_arg": "( variant { Init = record { index_id = null; max_blocks_per_request = 9_999 : nat64 }},)",
 			"remote": {
 				"id": {
+					"staging": "um5iw-rqaaa-aaaaq-qaaba-cai",
 					"ic": "um5iw-rqaaa-aaaaq-qaaba-cai"
 				}
 			}
@@ -57,6 +58,7 @@
 			"wasm": "https://github.com/dfinity/internet-identity/releases/latest/download/internet_identity_dev.wasm.gz",
 			"remote": {
 				"id": {
+					"staging": "rdmx6-jaaaa-aaaaa-aaadq-cai",
 					"ic": "rdmx6-jaaaa-aaaaa-aaadq-cai"
 				}
 			},


### PR DESCRIPTION
# Motivation
The remote canister IDs need to be specified for staging.

# Changes
- Specify the canister IDs for `internet_identity` and `cycles_ledger` on the staging network.

# Tests
`dfx build signer --network staging` now works.