### PR TITLE
feat(devops): Add signer candid in build artefacts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -91,9 +91,10 @@ COPY canister_ids.json canister_ids.json
 COPY scripts/build.signer.sh scripts/build.signer.args.sh scripts/
 RUN touch src/*/src/*.rs
 RUN dfx build --ic signer
-RUN cp out/signer.wasm.gz out/signer.args.did /
-RUN sha256sum /signer.wasm.gz /signer.args.did
+RUN cp out/signer.wasm.gz out/signer.args.did out/signer.did /
+RUN sha256sum /signer.wasm.gz /signer.args.did signer.did
 
 FROM scratch AS signer
 COPY --from=build-signer /signer.wasm.gz /
 COPY --from=build-signer /signer.args.did /
+COPY --from=build-signer /signer.did /

--- a/dfx.json
+++ b/dfx.json
@@ -39,6 +39,7 @@
 			"init_arg": "( variant { Init = record { index_id = null; max_blocks_per_request = 9_999 : nat64 }},)",
 			"remote": {
 				"id": {
+					"staging": "um5iw-rqaaa-aaaaq-qaaba-cai",
 					"ic": "um5iw-rqaaa-aaaaq-qaaba-cai"
 				}
 			}
@@ -57,6 +58,7 @@
 			"wasm": "https://github.com/dfinity/internet-identity/releases/latest/download/internet_identity_dev.wasm.gz",
 			"remote": {
 				"id": {
+					"staging": "rdmx6-jaaaa-aaaaa-aaadq-cai",
 					"ic": "rdmx6-jaaaa-aaaaa-aaadq-cai"
 				}
 			},

--- a/scripts/build.signer.sh
+++ b/scripts/build.signer.sh
@@ -54,6 +54,10 @@ mv "$BUILD_DIR/signer.metadata.wasm.gz" "$WASM_FILE"
 ./scripts/build.signer.args.sh
 
 ####
+# Adds the candid file to the output directory
+cp src/signer/canister/signer.did out/
+
+####
 # Success
 cat <<EOF
 SUCCESS: The signer installation files have been created:


### PR DESCRIPTION
# Motivation
Releases should really contain the canister API did.  Users cannot be expected to search through the code to find the .did, especially when the .did file in the code can move.

# Changes
Add signer.did to the build artefacts and so release.

# Tests
- Release run from a test release of this PR: https://github.com/dfinity/chain-fusion-signer/actions/runs/10996279002
- Local `dfx build signer` (after creating the ledger canister) includes `out/signer.did`.
- Local docker build includes `out/signer.did`.
