### PR TITLE
feat(signer): Add payment error as a bitcoin response variant

### DIFF
--- a/src/signer/api/src/impls.rs
+++ b/src/signer/api/src/impls.rs
@@ -1,5 +1,9 @@
-use crate::types::{Config, InitArg};
+use crate::types::{
+    bitcoin::{GetAddressError, GetBalanceError},
+    Config, InitArg,
+};
 use ic_canister_sig_creation::{extract_raw_root_pk_from_der, IC_ROOT_PK_DER};
+use ic_papi_api::PaymentError;
 
 impl From<InitArg> for Config {
     /// Creates a new `Config` from the provided `InitArg`.
@@ -25,5 +29,17 @@ impl From<InitArg> for Config {
             ic_root_key_raw: Some(ic_root_key_raw),
             cycles_ledger,
         }
+    }
+}
+
+impl From<PaymentError> for GetAddressError {
+    fn from(e: PaymentError) -> Self {
+        GetAddressError::PaymentError(e)
+    }
+}
+
+impl From<PaymentError> for GetBalanceError {
+    fn from(e: PaymentError) -> Self {
+        GetBalanceError::PaymentError(e)
     }
 }

--- a/src/signer/api/src/types.rs
+++ b/src/signer/api/src/types.rs
@@ -46,6 +46,7 @@ pub mod transaction {
 pub mod bitcoin {
     use candid::{CandidType, Deserialize};
     use ic_cdk::api::management_canister::bitcoin::BitcoinNetwork;
+    use ic_papi_api::PaymentError;
 
     #[derive(CandidType, Deserialize, Debug)]
     pub enum BitcoinAddressType {
@@ -66,6 +67,7 @@ pub mod bitcoin {
     #[derive(CandidType, Deserialize, Debug)]
     pub enum GetAddressError {
         InternalError { msg: String },
+        PaymentError(PaymentError),
     }
 
     #[derive(CandidType, Deserialize, Debug)]
@@ -82,5 +84,6 @@ pub mod bitcoin {
     #[derive(CandidType, Deserialize, Debug)]
     pub enum GetBalanceError {
         InternalError { msg: String },
+        PaymentError(PaymentError),
     }
 }


### PR DESCRIPTION
# Motivation
When the bitcoin APIs start charging for access, a possible error condition is failed payment.

# Changes
- Add `PaymentError` as a variant for the Bitcoin API response types.

# Tests
None; this variant is not used yet.