### PR TITLE
feat(signer): Add a generic signing API

### DIFF
--- a/src/signer/canister/src/derivation_path.rs
+++ b/src/signer/canister/src/derivation_path.rs
@@ -12,6 +12,8 @@ pub enum Schema {
     ///
     /// Please see `from_principal` for details.
     Eth = 1,
+    /// A generic ECDSA key.  The caller is responsible for managing derivation paths.
+    Generic = 0xff,
 }
 
 impl From<Schema> for Vec<u8> {
@@ -25,5 +27,14 @@ impl Schema {
     /// The caller may specify any derivation path, as long as it starts with schema and caller principal.
     pub fn derivation_path(self, principal: &Principal) -> Vec<Vec<u8>> {
         vec![self.into(), principal.as_slice().to_vec()]
+    }
+    pub fn derivation_path_ending_in(
+        self,
+        principal: &Principal,
+        mut ending: Vec<Vec<u8>>,
+    ) -> Vec<Vec<u8>> {
+        let mut path = self.derivation_path(principal);
+        path.append(&mut ending);
+        path
     }
 }

--- a/src/signer/canister/src/sign/generic.rs
+++ b/src/signer/canister/src/sign/generic.rs
@@ -1,0 +1,49 @@
+//! A generic signing API equivalent to that provided by the canister API.
+use crate::derivation_path::Schema;
+use candid::{CandidType, Deserialize};
+use ic_cdk::api::call::RejectionCode;
+use ic_cdk::api::management_canister::ecdsa::{
+    ecdsa_public_key, sign_with_ecdsa, EcdsaPublicKeyArgument, EcdsaPublicKeyResponse,
+    SignWithEcdsaArgument, SignWithEcdsaResponse,
+};
+
+/// Signs a message with a generic ECDSA key for the user.
+///
+/// Warning: The user supplied derivation path is used as-is.  The caller is responsible for ensuring that unintended sub-keys are not requested.
+pub async fn generic_ecdsa_public_key(
+    mut arg: EcdsaPublicKeyArgument,
+) -> Result<(EcdsaPublicKeyResponse,), GenericSigningError> {
+    arg.derivation_path =
+        Schema::Generic.derivation_path_ending_in(&ic_cdk::caller(), arg.derivation_path);
+    ecdsa_public_key(arg)
+        .await
+        .map_err(|(rejection_code, message)| {
+            GenericSigningError::SigningError(rejection_code, message)
+        })
+}
+
+pub async fn generic_sign_with_ecdsa(
+    mut arg: SignWithEcdsaArgument,
+) -> Result<(SignWithEcdsaResponse,), GenericSigningError> {
+    arg.derivation_path =
+        Schema::Generic.derivation_path_ending_in(&ic_cdk::caller(), arg.derivation_path);
+    sign_with_ecdsa(arg)
+        .await
+        .map_err(|(rejection_code, message)| {
+            GenericSigningError::SigningError(rejection_code, message)
+        })
+}
+
+#[derive(CandidType, Deserialize, Debug, Clone)]
+pub enum GenericSigningError {
+    /// Payment failed.
+    PaymentError(ic_papi_api::PaymentError),
+    /// An `ic_cdk::call::CallResult` error received when making the canister thereshold signature API call.
+    SigningError(RejectionCode, String),
+}
+
+impl From<ic_papi_api::PaymentError> for GenericSigningError {
+    fn from(e: ic_papi_api::PaymentError) -> Self {
+        Self::PaymentError(e)
+    }
+}

--- a/src/signer/canister/src/sign/mod.rs
+++ b/src/signer/canister/src/sign/mod.rs
@@ -1,2 +1,3 @@
 pub mod bitcoin;
 pub mod eth;
+pub mod generic;


### PR DESCRIPTION
# Motivation
We would like to have a generic signing API, as well as dedicated APIs for specific chains.

# Changes
- Add a generic signing API and schema.

# Tests
None yet, but needed!