### PR TITLE
feat(signer): Better error reporting in btc_caller_send

### DIFF
--- a/src/signer/api/src/types.rs
+++ b/src/signer/api/src/types.rs
@@ -108,8 +108,17 @@ pub mod bitcoin {
     }
 
     #[derive(CandidType, Deserialize, Debug)]
+    pub enum BuildP2wpkhTxError {
+        NotP2WPKHSourceAddress,
+        InvalidDestinationAddress { address: String },
+        InvalidSourceAddress { address: String },
+        WrongBitcoinNetwork,
+    }
+
+    #[derive(CandidType, Deserialize, Debug)]
     pub enum SendBtcError {
         InternalError { msg: String },
         PaymentError(PaymentError),
+        BuildP2wpkhError(BuildP2wpkhTxError),
     }
 }

--- a/src/signer/canister/signer.did
+++ b/src/signer/canister/signer.did
@@ -3,6 +3,12 @@ type Arg = variant { Upgrade; Init : InitArg };
 type BitcoinAddressType = variant { P2WPKH };
 type BitcoinNetwork = variant { mainnet; regtest; testnet };
 type BtcTxOutput = record { destination_address : text; sent_satoshis : nat64 };
+type BuildP2wpkhTxError = variant {
+  WrongBitcoinNetwork;
+  NotP2WPKHSourceAddress;
+  InvalidDestinationAddress : GetAddressResponse;
+  InvalidSourceAddress : GetAddressResponse;
+};
 type CallerPaysIcrc2Tokens = record { ledger : principal };
 type CanisterStatusResultV2 = record {
   controller : principal;
@@ -69,9 +75,16 @@ type InitArg = record {
 type Outpoint = record { txid : blob; vout : nat32 };
 type PatronPaysIcrc2Tokens = record { ledger : principal; patron : Account };
 type PaymentError = variant {
+  LedgerWithdrawFromError : record {
+    error : WithdrawFromError;
+    ledger : principal;
+  };
   LedgerUnreachable : CallerPaysIcrc2Tokens;
+  LedgerTransferFromError : record {
+    error : TransferFromError;
+    ledger : principal;
+  };
   UnsupportedPaymentType;
-  LedgerError : record { error : WithdrawFromError; ledger : principal };
   InsufficientFunds : record { needed : nat64; available : nat64 };
 };
 type PaymentType = variant {
@@ -112,6 +125,7 @@ type Result_5 = variant {
   Err : GenericSigningError;
 };
 type SendBtcError = variant {
+  BuildP2wpkhError : BuildP2wpkhTxError;
   InternalError : record { msg : text };
   PaymentError : PaymentError;
 };
@@ -139,6 +153,17 @@ type SignWithEcdsaArgument = record {
   message_hash : blob;
 };
 type SignWithEcdsaResponse = record { signature : blob };
+type TransferFromError = variant {
+  GenericError : record { message : text; error_code : nat };
+  TemporarilyUnavailable;
+  InsufficientAllowance : record { allowance : nat };
+  BadBurn : record { min_burn_amount : nat };
+  Duplicate : record { duplicate_of : nat };
+  BadFee : record { expected_fee : nat };
+  CreatedInFuture : record { ledger_time : nat64 };
+  TooOld;
+  InsufficientFunds : record { balance : nat };
+};
 type Utxo = record { height : nat32; value : nat64; outpoint : Outpoint };
 type WithdrawFromError = variant {
   GenericError : record { message : text; error_code : nat };

--- a/src/signer/canister/src/lib.rs
+++ b/src/signer/canister/src/lib.rs
@@ -350,7 +350,7 @@ async fn btc_caller_send(
                 params.outputs,
             )
             .await
-            .map_err(|msg| SendBtcError::InternalError { msg })?;
+            .map_err(|err| SendBtcError::BuildP2wpkhError(err))?;
 
             let signed_transaction = btc_sign_transaction(
                 &principal,

--- a/src/signer/canister/src/lib.rs
+++ b/src/signer/canister/src/lib.rs
@@ -350,7 +350,7 @@ async fn btc_caller_send(
                 params.outputs,
             )
             .await
-            .map_err(|err| SendBtcError::BuildP2wpkhError(err))?;
+            .map_err(SendBtcError::BuildP2wpkhError)?;
 
             let signed_transaction = btc_sign_transaction(
                 &principal,

--- a/src/signer/canister/src/sign/bitcoin/tx_utils.rs
+++ b/src/signer/canister/src/sign/bitcoin/tx_utils.rs
@@ -13,7 +13,7 @@ use bitcoin::{
 };
 use candid::Principal;
 use ic_cdk::api::management_canister::bitcoin::{BitcoinNetwork, Utxo};
-use ic_chain_fusion_signer_api::types::bitcoin::BtcTxOutput;
+use ic_chain_fusion_signer_api::types::bitcoin::{BtcTxOutput, BuildP2wpkhTxError};
 use std::str::FromStr;
 
 const ECDSA_SIG_HASH_TYPE: EcdsaSighashType = EcdsaSighashType::All;
@@ -63,14 +63,14 @@ pub async fn build_p2wpkh_transaction(
     utxos_to_spend: &[Utxo],
     fee: u64,
     request_outputs: Vec<BtcTxOutput>,
-) -> Result<Transaction, String> {
+) -> Result<Transaction, BuildP2wpkhTxError> {
     // Assume that any amount below this threshold is dust.
     const DUST_THRESHOLD: u64 = 1_000;
 
     let own_address = Address::from_str(&source_address)
-        .unwrap()
+        .map_err(|_| BuildP2wpkhTxError::InvalidSourceAddress { address: source_address.clone() })?
         .require_network(transform_network(network))
-        .expect("Network check failed");
+        .map_err(|_| BuildP2wpkhTxError::WrongBitcoinNetwork)?;
 
     assert_eq!(
         own_address.address_type(),
@@ -93,36 +93,50 @@ pub async fn build_p2wpkh_transaction(
 
     let total_spent: u64 = utxos_to_spend.iter().map(|u| u.value).sum();
 
-    let mut outputs: Vec<TxOut> = request_outputs
+    let outputs_result: Result<Vec<TxOut>, BuildP2wpkhTxError> = request_outputs
         .iter()
-        .map(|output| TxOut {
-            script_pubkey: Address::from_str(&output.destination_address)
-                .unwrap()
+        .map(|output| {
+            let address = Address::from_str(&output.destination_address)
+                .map_err(|_| BuildP2wpkhTxError::InvalidDestinationAddress {
+                    address: output.destination_address.clone(),
+                })?; // Convert from ParseError to BuildP2wpkhError
+    
+            let address = address
                 .require_network(transform_network(network))
-                .map(|address| address.script_pubkey())
-                .expect("Failed decoding destination address"),
-            value: Amount::from_sat(output.sent_satoshis),
+                .map_err(|_| BuildP2wpkhTxError::WrongBitcoinNetwork)?; // Convert from ParseError to BuildP2wpkhError
+    
+            Ok(TxOut {
+                script_pubkey: address.script_pubkey(),
+                value: Amount::from_sat(output.sent_satoshis),
+            })
         })
         .collect();
-
-    let sent_amount: u64 = outputs.iter().map(|u| u.value.to_sat()).sum();
-    // The fee is set with leaving that amount of difference between the inputs and outputs values.
-    // For example, if the inputs sum 200 and the fee is 20, then the outputs should sum 180.
-    let remaining_amount = total_spent - sent_amount - fee;
-
-    if remaining_amount >= DUST_THRESHOLD {
-        outputs.push(TxOut {
-            script_pubkey: own_address.script_pubkey(),
-            value: Amount::from_sat(remaining_amount),
-        });
+    
+    match outputs_result {
+        Ok(mut outputs) => {
+            let sent_amount: u64 = outputs.iter().map(|u| u.value.to_sat()).sum();
+            // The fee is set with leaving that amount of difference between the inputs and outputs values.
+            // For example, if the inputs sum 200 and the fee is 20, then the outputs should sum 180.
+            let remaining_amount = total_spent - sent_amount - fee;
+        
+            if remaining_amount >= DUST_THRESHOLD {
+                outputs.push(TxOut {
+                    script_pubkey: own_address.script_pubkey(),
+                    value: Amount::from_sat(remaining_amount),
+                });
+            }
+        
+            Ok(Transaction {
+                input: inputs,
+                output: outputs,
+                lock_time: LockTime::ZERO,
+                version: Version::TWO,
+            })
+        },
+        Err(e) => {
+            Err(e)
+        }
     }
-
-    Ok(Transaction {
-        input: inputs,
-        output: outputs,
-        lock_time: LockTime::ZERO,
-        version: Version::TWO,
-    })
 }
 
 fn get_input_value(input: &TxIn, outputs: &[Utxo]) -> Option<Amount> {


### PR DESCRIPTION
# Motivation

Clients should be able to differentiate errors when sending bitcoins and act differently depending on the error.

In this PR, I introduce one more enum in the error response for `btc_caller_send`: `BuildP2wpkhError`.

# Changes

* New enum `BuildP2wpkhTxError` for error reporting.
* Update signer candid file.
* `build_p2wpkh_transaction` returns a `BuildP2wpkhTxError` instead of a String if error.

# Tests

Unfortunately we can't add tests for this yet. We need to upgrade pocket-ic when this supports bitcoin.
