### PR TITLE
fix(devops): Update codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,11 @@
+# IMPORTANT: The last matching entry has the highest precedence.
+
+# The GIX team members who maintain this repo.
+# Note: These users will receive GitHub notifications for PRs.
+#       The list is kept short to avoid spamming the whole team.
+#       If standard maintainers are not available, please contact GIX.
+* @bitdivine
+
 # The codebase is owned by the Governance & Identity Experience team at DFINITY
 # For questions, reach out to: <gix@dfinity.org>
 .github/CODEOWNERS @dfinity/gix
-# The GIX team members who maintain this repo:
-* @bitdivine


### PR DESCRIPTION
# Motivation
In GitHub codeowners files,  the last matching entry, not the first, takes precedence.  This is mentioned in [the CODEOWNERS example](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#example-of-a-codeowners-file).  The CODEOWNERS file was written assuming that the first match takes precendence.

# Changes
- Reverse the entries in the codeowners file and add a comment explaining the order.

# Tests
<!-- Please provide any information or screenshots about the tests that have been done -->
