### PR TITLE
fix(signer): Return error if not enough funds to cover amount plus fee

### DIFF
--- a/src/signer/api/src/types.rs
+++ b/src/signer/api/src/types.rs
@@ -113,6 +113,7 @@ pub mod bitcoin {
         InvalidDestinationAddress { address: String },
         InvalidSourceAddress { address: String },
         WrongBitcoinNetwork,
+        NotEnoughFunds { required: u64, available: u64 },
     }
 
     #[derive(CandidType, Deserialize, Debug)]

--- a/src/signer/canister/src/lib.rs
+++ b/src/signer/canister/src/lib.rs
@@ -343,11 +343,11 @@ async fn btc_caller_send(
             .map_err(|msg| SendBtcError::InternalError { msg })?;
 
             let transaction = build_p2wpkh_transaction(
-                source_address.clone(),
+                &source_address,
                 params.network,
                 &params.utxos_to_spend,
                 fee,
-                params.outputs,
+                &params.outputs,
             )
             .map_err(SendBtcError::BuildP2wpkhError)?;
 

--- a/src/signer/canister/src/lib.rs
+++ b/src/signer/canister/src/lib.rs
@@ -349,7 +349,6 @@ async fn btc_caller_send(
                 fee,
                 params.outputs,
             )
-            .await
             .map_err(SendBtcError::BuildP2wpkhError)?;
 
             let signed_transaction = btc_sign_transaction(

--- a/src/signer/canister/src/sign/bitcoin/tx_utils.rs
+++ b/src/signer/canister/src/sign/bitcoin/tx_utils.rs
@@ -83,15 +83,15 @@ fn calculate_remaining_amount(
 }
 
 pub fn build_p2wpkh_transaction(
-    source_address: String,
+    source_address: &str,
     network: BitcoinNetwork,
     utxos_to_spend: &[Utxo],
     fee: u64,
-    request_outputs: Vec<BtcTxOutput>,
+    request_outputs: &[BtcTxOutput],
 ) -> Result<Transaction, BuildP2wpkhTxError> {
-    let own_address = Address::from_str(&source_address)
+    let own_address = Address::from_str(source_address)
         .map_err(|_| BuildP2wpkhTxError::InvalidSourceAddress {
-            address: source_address.clone(),
+            address: source_address.to_string(),
         })?
         .require_network(transform_network(network))
         .map_err(|_| BuildP2wpkhTxError::WrongBitcoinNetwork)?;
@@ -364,7 +364,7 @@ mod tests {
 
     #[test]
     fn test_build_p2wpkh_transaction_not_enough_funds() {
-        let source_address = "bc1qxy2kgdygjrsqtzq2n0yrf2493p83kkfjhx0wlh".to_string(); // Valid source address
+        let source_address = "bc1qxy2kgdygjrsqtzq2n0yrf2493p83kkfjhx0wlh"; // Valid source address
 
         let mock_utxos = get_mock_utxos();
         let first_mock = mock_utxos.first().unwrap();
@@ -376,7 +376,7 @@ mod tests {
             BitcoinNetwork::Mainnet,
             &utxos,
             tx_fee,
-            vec![BtcTxOutput {
+            &vec![BtcTxOutput {
                 destination_address: "bc1qxy2kgdygjrsqtzq2n0yrf2493p83kkfjhx0wlh".to_string(),
                 sent_satoshis: first_mock.utxo.value,
             }],
@@ -396,14 +396,14 @@ mod tests {
 
     #[test]
     fn test_build_p2wpkh_transaction_invalid_source_address() {
-        let invalid_address = "invalid_address".to_string();
+        let invalid_address = "invalid_address";
 
         let result = build_p2wpkh_transaction(
             invalid_address.clone(),
             BitcoinNetwork::Mainnet,
             &[],
             10,
-            vec![],
+            &vec![],
         );
 
         match result {
@@ -416,14 +416,14 @@ mod tests {
 
     #[test]
     fn test_build_p2wpkh_transaction_wrong_bitcoin_network() {
-        let source_address = "bc1qxy2kgdygjrsqtzq2n0yrf2493p83kkfjhx0wlh".to_string(); // Valid mainnet P2wpkh address
+        let source_address = "bc1qxy2kgdygjrsqtzq2n0yrf2493p83kkfjhx0wlh"; // Valid mainnet P2wpkh address
 
         let result = build_p2wpkh_transaction(
             source_address,
             BitcoinNetwork::Testnet, // Incorrect network for the address
             &[],
             10,
-            vec![],
+            &vec![],
         );
 
         match result {
@@ -434,7 +434,7 @@ mod tests {
 
     #[test]
     fn test_build_p2wpkh_transaction_invalid_destination_address() {
-        let source_address = "bc1qxy2kgdygjrsqtzq2n0yrf2493p83kkfjhx0wlh".to_string();
+        let source_address = "bc1qxy2kgdygjrsqtzq2n0yrf2493p83kkfjhx0wlh";
         let invalid_address = "invalid_destination".to_string();
 
         let result = build_p2wpkh_transaction(
@@ -442,7 +442,7 @@ mod tests {
             BitcoinNetwork::Mainnet,
             &[],
             10,
-            vec![BtcTxOutput {
+            &vec![BtcTxOutput {
                 destination_address: invalid_address.clone(),
                 sent_satoshis: 1000,
             }],
@@ -458,10 +458,10 @@ mod tests {
 
     #[test]
     fn test_build_p2wpkh_transaction_not_p2wpkh_source_address() {
-        let source_address = "1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa".to_string(); // This is a legacy P2PKH address, not P2WPKH
+        let source_address = "1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa"; // This is a legacy P2PKH address, not P2WPKH
 
         let result =
-            build_p2wpkh_transaction(source_address, BitcoinNetwork::Mainnet, &[], 10, vec![]);
+            build_p2wpkh_transaction(source_address, BitcoinNetwork::Mainnet, &[], 10, &vec![]);
 
         match result {
             Err(BuildP2wpkhTxError::NotP2WPKHSourceAddress) => {} // Success if this error is returned
@@ -471,7 +471,7 @@ mod tests {
 
     #[test]
     fn test_build_p2wpkh_transaction_successful_transaction() {
-        let source_address = "bc1qxy2kgdygjrsqtzq2n0yrf2493p83kkfjhx0wlh".to_string();
+        let source_address = "bc1qxy2kgdygjrsqtzq2n0yrf2493p83kkfjhx0wlh";
 
         let wrapped_utxos = get_mock_utxos();
         let utxos: Vec<Utxo> = wrapped_utxos
@@ -494,7 +494,7 @@ mod tests {
             BitcoinNetwork::Mainnet,
             &utxos,
             tx_fee,
-            request_outputs,
+            &request_outputs,
         );
 
         // Assert success

--- a/src/signer/canister/src/sign/bitcoin/tx_utils.rs
+++ b/src/signer/canister/src/sign/bitcoin/tx_utils.rs
@@ -396,13 +396,8 @@ mod tests {
     fn test_build_p2wpkh_transaction_invalid_source_address() {
         let invalid_address = "invalid_address";
 
-        let result = build_p2wpkh_transaction(
-            invalid_address,
-            BitcoinNetwork::Mainnet,
-            &[],
-            10,
-            &vec![],
-        );
+        let result =
+            build_p2wpkh_transaction(invalid_address, BitcoinNetwork::Mainnet, &[], 10, &vec![]);
 
         match result {
             Err(BuildP2wpkhTxError::InvalidSourceAddress { address }) => {

--- a/src/signer/canister/src/sign/bitcoin/tx_utils.rs
+++ b/src/signer/canister/src/sign/bitcoin/tx_utils.rs
@@ -96,11 +96,9 @@ pub fn build_p2wpkh_transaction(
         .require_network(transform_network(network))
         .map_err(|_| BuildP2wpkhTxError::WrongBitcoinNetwork)?;
 
-    assert_eq!(
-        own_address.address_type(),
-        Some(AddressType::P2wpkh),
-        "Address must be of type p2wpkh."
-    );
+    if own_address.address_type() != Some(AddressType::P2wpkh) {
+        return Err(BuildP2wpkhTxError::NotP2WPKHSourceAddress);
+    }
 
     let inputs: Vec<TxIn> = utxos_to_spend
         .iter()

--- a/src/signer/canister/src/sign/bitcoin/tx_utils.rs
+++ b/src/signer/canister/src/sign/bitcoin/tx_utils.rs
@@ -75,7 +75,10 @@ fn calculate_remaining_amount(
     {
         Ok(remaining_amount)
     } else {
-        Err(BuildP2wpkhTxError::NotEnoughFunds { required: sent_amount + fee, available: utxos_amount })
+        Err(BuildP2wpkhTxError::NotEnoughFunds {
+            required: sent_amount + fee,
+            available: utxos_amount,
+        })
     }
 }
 
@@ -236,9 +239,11 @@ mod tests {
     use std::str::FromStr;
 
     use bitcoin::{
-        hashes::Hash, OutPoint as BitcoinOutPoint, ScriptBuf, Sequence, TxIn, Txid, Witness
+        hashes::Hash, OutPoint as BitcoinOutPoint, ScriptBuf, Sequence, TxIn, Txid, Witness,
     };
-    use ic_cdk::api::management_canister::bitcoin::{BitcoinNetwork, Outpoint as IcCdkOutPoint, Utxo};
+    use ic_cdk::api::management_canister::bitcoin::{
+        BitcoinNetwork, Outpoint as IcCdkOutPoint, Utxo,
+    };
     use ic_chain_fusion_signer_api::types::bitcoin::{BtcTxOutput, BuildP2wpkhTxError};
 
     use super::{build_p2wpkh_transaction, get_input_value, DUST_THRESHOLD};
@@ -455,13 +460,8 @@ mod tests {
     fn test_build_p2wpkh_transaction_not_p2wpkh_source_address() {
         let source_address = "1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa".to_string(); // This is a legacy P2PKH address, not P2WPKH
 
-        let result = build_p2wpkh_transaction(
-            source_address,
-            BitcoinNetwork::Mainnet,
-            &[],
-            10,
-            vec![],
-        );
+        let result =
+            build_p2wpkh_transaction(source_address, BitcoinNetwork::Mainnet, &[], 10, vec![]);
 
         match result {
             Err(BuildP2wpkhTxError::NotP2WPKHSourceAddress) => {} // Success if this error is returned
@@ -474,7 +474,10 @@ mod tests {
         let source_address = "bc1qxy2kgdygjrsqtzq2n0yrf2493p83kkfjhx0wlh".to_string();
 
         let wrapped_utxos = get_mock_utxos();
-        let utxos: Vec<Utxo> = wrapped_utxos.iter().map(|wrapper| wrapper.utxo.clone()).collect();
+        let utxos: Vec<Utxo> = wrapped_utxos
+            .iter()
+            .map(|wrapper| wrapper.utxo.clone())
+            .collect();
         let utxos_amount: u64 = utxos.iter().map(|utxo| utxo.value).sum();
         let tx_fee = 400;
         let remaining = DUST_THRESHOLD * 2;
@@ -499,7 +502,7 @@ mod tests {
             Ok(tx) => {
                 assert_eq!(tx.input.len(), utxos.len());
                 assert_eq!(tx.output.len(), 2); // 2 outputs (one for the destination, one for the change)
-                
+
                 // Check that the first output matches the sent amount
                 assert_eq!(tx.output[0].value.to_sat(), amount_sent);
 

--- a/src/signer/canister/src/sign/bitcoin/tx_utils.rs
+++ b/src/signer/canister/src/sign/bitcoin/tx_utils.rs
@@ -399,7 +399,7 @@ mod tests {
         let invalid_address = "invalid_address";
 
         let result = build_p2wpkh_transaction(
-            invalid_address.clone(),
+            invalid_address,
             BitcoinNetwork::Mainnet,
             &[],
             10,


### PR DESCRIPTION
# Motivation

Issue raised by the security review F08.

Return an error from `build_p2wpkh_transaction` if remaining amount is less than zero.

# Changes

* Add entry to `BuildP2wpkhTxError` enum `NotEnoughFunds`.
* Helper to calculate the remaining amount and return error if less than zero.
* Use the helper instead of performing the calculation.
* Remove unnecessary`async` from `build_p2wpkh_transaction`.
* Changes in parameters due to lint issues.

# Tests

I realized that we could easily write tests for `build_p2wpkh_transaction`. Therefore, I added a test for each case.
