### PR TITLE
chore(rust): Group imports

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -21,6 +21,10 @@ jobs:
         run: ./scripts/setup cargo-binstall shfmt yq cargo-sort
       - name: Install node dependencies
         run: npm ci --no-audit
+      - name: Install nightly rust
+        run: |
+          rustup toolchain install nightly
+          rustup component add rustfmt --toolchain nightly
       - name: Format
         run: ./scripts/fmt
       - name: Ignore some changes

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,1 @@
+imports_granularity = "Crate"

--- a/scripts/fmt-rs
+++ b/scripts/fmt-rs
@@ -2,4 +2,4 @@
 set -euxo pipefail
 cd "$(dirname "$(realpath "$0")")/.."
 
-cargo fmt
+cargo +nightly fmt

--- a/src/signer/canister/src/lib.rs
+++ b/src/signer/canister/src/lib.rs
@@ -1,37 +1,35 @@
-use crate::guards::caller_is_not_anonymous;
-use crate::sign::generic::GenericSigningError;
+use crate::{guards::caller_is_not_anonymous, sign::generic::GenericSigningError};
 use candid::Principal;
-use ic_cdk::api::management_canister::ecdsa::EcdsaPublicKeyArgument;
-use ic_cdk::api::management_canister::ecdsa::EcdsaPublicKeyResponse;
-use ic_cdk::api::management_canister::ecdsa::SignWithEcdsaArgument;
-use ic_cdk::api::management_canister::ecdsa::SignWithEcdsaResponse;
-use ic_cdk_macros::{export_candid, init, post_upgrade, query, update};
-use ic_chain_fusion_signer_api::http::HttpRequest;
-use ic_chain_fusion_signer_api::http::HttpResponse;
-use ic_chain_fusion_signer_api::metrics::get_metrics;
-use ic_chain_fusion_signer_api::std_canister_status;
-use ic_chain_fusion_signer_api::types::bitcoin::GetAddressError;
-use ic_chain_fusion_signer_api::types::bitcoin::GetAddressRequest;
-use ic_chain_fusion_signer_api::types::bitcoin::GetAddressResponse;
-use ic_chain_fusion_signer_api::types::bitcoin::GetBalanceRequest;
-use ic_chain_fusion_signer_api::types::bitcoin::SendBtcError;
-use ic_chain_fusion_signer_api::types::bitcoin::SendBtcRequest;
-use ic_chain_fusion_signer_api::types::bitcoin::SendBtcResponse;
-use ic_chain_fusion_signer_api::types::bitcoin::{
-    BitcoinAddressType, GetBalanceError, GetBalanceResponse,
+use ic_cdk::api::management_canister::ecdsa::{
+    EcdsaPublicKeyArgument, EcdsaPublicKeyResponse, SignWithEcdsaArgument, SignWithEcdsaResponse,
 };
-use ic_chain_fusion_signer_api::types::transaction::SignRequest;
-use ic_chain_fusion_signer_api::types::{Arg, Config};
+use ic_cdk_macros::{export_candid, init, post_upgrade, query, update};
+use ic_chain_fusion_signer_api::{
+    http::{HttpRequest, HttpResponse},
+    metrics::get_metrics,
+    std_canister_status,
+    types::{
+        bitcoin::{
+            BitcoinAddressType, GetAddressError, GetAddressRequest, GetAddressResponse,
+            GetBalanceError, GetBalanceRequest, GetBalanceResponse, SendBtcError, SendBtcRequest,
+            SendBtcResponse,
+        },
+        transaction::SignRequest,
+        Arg, Config,
+    },
+};
 use ic_papi_api::PaymentType;
 use ic_papi_guard::guards::{PaymentContext, PaymentGuard2};
 use serde_bytes::ByteBuf;
-use sign::bitcoin::fee_utils::calculate_fee;
-use sign::bitcoin::tx_utils::btc_sign_transaction;
-use sign::bitcoin::tx_utils::build_p2wpkh_transaction;
-use sign::bitcoin::{bitcoin_api, bitcoin_utils};
-use sign::eth;
-use sign::generic;
-use sign::generic::generic_ecdsa_public_key;
+use sign::{
+    bitcoin::{
+        bitcoin_api, bitcoin_utils,
+        fee_utils::calculate_fee,
+        tx_utils::{btc_sign_transaction, build_p2wpkh_transaction},
+    },
+    eth, generic,
+    generic::generic_ecdsa_public_key,
+};
 use state::{read_config, read_state, set_config, PAYMENT_GUARD};
 
 mod convert;

--- a/src/signer/canister/src/sign/bitcoin/bitcoin_utils.rs
+++ b/src/signer/canister/src/sign/bitcoin/bitcoin_utils.rs
@@ -1,11 +1,10 @@
 //! Code for signing Bitcoin transactions.
-use crate::derivation_path::Schema;
-use crate::state::read_config;
+use crate::{derivation_path::Schema, state::read_config};
 use bitcoin::{Address, CompressedPublicKey, Network};
 use candid::Principal;
-use ic_cdk::api::management_canister::bitcoin::BitcoinNetwork;
-use ic_cdk::api::management_canister::ecdsa::{
-    ecdsa_public_key, EcdsaCurve, EcdsaKeyId, EcdsaPublicKeyArgument,
+use ic_cdk::api::management_canister::{
+    bitcoin::BitcoinNetwork,
+    ecdsa::{ecdsa_public_key, EcdsaCurve, EcdsaKeyId, EcdsaPublicKeyArgument},
 };
 
 /// Computes the public key of the specified principal.

--- a/src/signer/canister/src/sign/bitcoin/tx_utils.rs
+++ b/src/signer/canister/src/sign/bitcoin/tx_utils.rs
@@ -5,10 +5,9 @@ use crate::{
         ecdsa_api::{ecdsa_pubkey_of, get_ecdsa_signature},
     },
 };
-use bitcoin::consensus::serialize;
 use bitcoin::{
-    absolute::LockTime, hashes::Hash, script::PushBytesBuf, sighash::SighashCache,
-    transaction::Version, Address, AddressType, Amount, EcdsaSighashType,
+    absolute::LockTime, consensus::serialize, hashes::Hash, script::PushBytesBuf,
+    sighash::SighashCache, transaction::Version, Address, AddressType, Amount, EcdsaSighashType,
     OutPoint as BitcoinOutPoint, ScriptBuf, Sequence, Transaction, TxIn, TxOut, Txid, Witness,
 };
 use candid::Principal;

--- a/src/signer/canister/src/sign/eth.rs
+++ b/src/signer/canister/src/sign/eth.rs
@@ -1,10 +1,14 @@
-use crate::convert::{decode_hex, nat_to_u256, nat_to_u64};
-use crate::derivation_path::Schema;
-use crate::state::read_config;
+use crate::{
+    convert::{decode_hex, nat_to_u256, nat_to_u64},
+    derivation_path::Schema,
+    state::read_config,
+};
 use candid::Principal;
-use ethers_core::abi::ethereum_types::{Address, U256};
-use ethers_core::types::transaction::eip2930::AccessList;
-use ethers_core::utils::keccak256;
+use ethers_core::{
+    abi::ethereum_types::{Address, U256},
+    types::transaction::eip2930::AccessList,
+    utils::keccak256,
+};
 use ic_cdk::api::management_canister::ecdsa::{
     ecdsa_public_key, sign_with_ecdsa, EcdsaCurve, EcdsaKeyId, EcdsaPublicKeyArgument,
     SignWithEcdsaArgument,
@@ -83,8 +87,7 @@ pub async fn sign_prehash(prehash: String) -> String {
 
 /// Computes a signature for an [EIP-1559](https://eips.ethereum.org/EIPS/eip-1559) transaction.
 pub async fn sign_transaction(req: SignRequest) -> String {
-    use ethers_core::types::transaction::eip1559::Eip1559TransactionRequest;
-    use ethers_core::types::Signature;
+    use ethers_core::types::{transaction::eip1559::Eip1559TransactionRequest, Signature};
 
     const EIP1559_TX_ID: u8 = 2;
 

--- a/src/signer/canister/src/sign/generic.rs
+++ b/src/signer/canister/src/sign/generic.rs
@@ -1,10 +1,12 @@
 //! A generic signing API equivalent to that provided by the canister API.
 use crate::derivation_path::Schema;
 use candid::{CandidType, Deserialize};
-use ic_cdk::api::call::RejectionCode;
-use ic_cdk::api::management_canister::ecdsa::{
-    ecdsa_public_key, sign_with_ecdsa, EcdsaPublicKeyArgument, EcdsaPublicKeyResponse,
-    SignWithEcdsaArgument, SignWithEcdsaResponse,
+use ic_cdk::api::{
+    call::RejectionCode,
+    management_canister::ecdsa::{
+        ecdsa_public_key, sign_with_ecdsa, EcdsaPublicKeyArgument, EcdsaPublicKeyResponse,
+        SignWithEcdsaArgument, SignWithEcdsaResponse,
+    },
 };
 
 /// Signs a message with a generic ECDSA key for the user.

--- a/src/signer/canister/tests/it/address.rs
+++ b/src/signer/canister/tests/it/address.rs
@@ -1,8 +1,10 @@
-use crate::utils::mock::{
-    CALLER, CALLER_BTC_ADDRESS_MAINNET, CALLER_BTC_ADDRESS_REGTEST, CALLER_BTC_ADDRESS_TESTNET,
-    CALLER_ETH_ADDRESS,
+use crate::utils::{
+    mock::{
+        CALLER, CALLER_BTC_ADDRESS_MAINNET, CALLER_BTC_ADDRESS_REGTEST, CALLER_BTC_ADDRESS_TESTNET,
+        CALLER_ETH_ADDRESS,
+    },
+    pocketic::{setup, PicCanisterTrait},
 };
-use crate::utils::pocketic::{setup, PicCanisterTrait};
 use candid::Principal;
 use ic_cdk::api::management_canister::bitcoin::BitcoinNetwork;
 use ic_chain_fusion_signer_api::types::bitcoin::{

--- a/src/signer/canister/tests/it/bitcoin.rs
+++ b/src/signer/canister/tests/it/bitcoin.rs
@@ -1,5 +1,7 @@
-use crate::utils::mock::CALLER;
-use crate::utils::pocketic::{setup, PicCanisterTrait};
+use crate::utils::{
+    mock::CALLER,
+    pocketic::{setup, PicCanisterTrait},
+};
 use candid::Principal;
 use ic_cdk::api::management_canister::bitcoin::BitcoinNetwork;
 use ic_chain_fusion_signer_api::types::bitcoin::{

--- a/src/signer/canister/tests/it/sign.rs
+++ b/src/signer/canister/tests/it/sign.rs
@@ -1,5 +1,7 @@
-use crate::utils::mock::{CALLER, CALLER_ETH_ADDRESS, SEPOLIA_CHAIN_ID};
-use crate::utils::pocketic::{setup, PicCanisterTrait};
+use crate::utils::{
+    mock::{CALLER, CALLER_ETH_ADDRESS, SEPOLIA_CHAIN_ID},
+    pocketic::{setup, PicCanisterTrait},
+};
 use candid::{Nat, Principal};
 use ic_chain_fusion_signer_api::types::transaction::SignRequest;
 

--- a/src/signer/canister/tests/it/utils/pocketic.rs
+++ b/src/signer/canister/tests/it/utils/pocketic.rs
@@ -3,10 +3,13 @@ use ic_cdk::api::management_canister::bitcoin::BitcoinNetwork;
 use ic_chain_fusion_signer_api::types::{Arg, InitArg};
 use pocket_ic::{CallError, PocketIc, PocketIcBuilder, WasmResult};
 use serde::Deserialize;
-use std::fs::read;
-use std::path::{Path, PathBuf};
-use std::sync::Arc;
-use std::{env, time::Duration};
+use std::{
+    env,
+    fs::read,
+    path::{Path, PathBuf},
+    sync::Arc,
+    time::Duration,
+};
 
 use super::mock::CONTROLLER;
 


### PR DESCRIPTION
# Motivation
The rust imports section is formatted erratically.

# Changes
- Use the nightly rustfmt.
- Group imports by crate.

# Tests
See CI