### PR TITLE
chore(devops): Bump release version to 0.2.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -404,7 +404,7 @@ dependencies = [
 
 [[package]]
 name = "cycles-ledger-client"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "candid",
  "ic-cdk 0.16.0",
@@ -604,7 +604,7 @@ dependencies = [
 
 [[package]]
 name = "example_backend"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "candid",
  "ic-cdk 0.16.0",
@@ -1082,7 +1082,7 @@ dependencies = [
 
 [[package]]
 name = "ic-chain-fusion-signer-api"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "candid",
  "ic-canister-sig-creation",
@@ -1119,7 +1119,7 @@ checksum = "8b5c7628eac357aecda461130f8074468be5aa4d258a002032d82d817f79f1f8"
 
 [[package]]
 name = "ic-papi-api"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "candid",
  "cycles-ledger-client",
@@ -1131,7 +1131,7 @@ dependencies = [
 
 [[package]]
 name = "ic-papi-guard"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "candid",
  "cycles-ledger-client",
@@ -2343,7 +2343,7 @@ dependencies = [
 
 [[package]]
 name = "signer"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "bitcoin",
  "candid",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1119,7 +1119,7 @@ checksum = "8b5c7628eac357aecda461130f8074468be5aa4d258a002032d82d817f79f1f8"
 
 [[package]]
 name = "ic-papi-api"
-version = "0.1.2"
+version = "0.2.3"
 dependencies = [
  "candid",
  "cycles-ledger-client",
@@ -1131,7 +1131,7 @@ dependencies = [
 
 [[package]]
 name = "ic-papi-guard"
-version = "0.1.2"
+version = "0.2.3"
 dependencies = [
  "candid",
  "cycles-ledger-client",

--- a/src/example_backend/Cargo.toml
+++ b/src/example_backend/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "example_backend"
-version = "0.2.2"
+version = "0.2.3"
 edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/src/papi/api/Cargo.toml
+++ b/src/papi/api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ic-papi-api"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 
 [dependencies]

--- a/src/papi/api/Cargo.toml
+++ b/src/papi/api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ic-papi-api"
-version = "0.1.2"
+version = "0.2.3"
 edition = "2021"
 
 [dependencies]

--- a/src/papi/cycles_ledger_client/Cargo.toml
+++ b/src/papi/cycles_ledger_client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cycles-ledger-client"
-version = "0.2.2"
+version = "0.2.3"
 edition = "2021"
 
 [dependencies]

--- a/src/papi/guard/Cargo.toml
+++ b/src/papi/guard/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ic-papi-guard"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 
 [dependencies]

--- a/src/papi/guard/Cargo.toml
+++ b/src/papi/guard/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ic-papi-guard"
-version = "0.1.2"
+version = "0.2.3"
 edition = "2021"
 
 [dependencies]

--- a/src/signer/api/Cargo.toml
+++ b/src/signer/api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ic-chain-fusion-signer-api"
-version = "0.2.2"
+version = "0.2.3"
 edition = "2021"
 
 [dependencies]

--- a/src/signer/canister/Cargo.toml
+++ b/src/signer/canister/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "signer"
-version = "0.2.2"
+version = "0.2.3"
 edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
# Motivation
There have been significant updates to the signer, so we would like to cut a release.

# Changes
- Increment release version

# Tests
No code changes, but see CI.