### PR TITLE
feat(signer): Add min_confirmations param to btc balance

### DIFF
--- a/src/signer/api/src/types.rs
+++ b/src/signer/api/src/types.rs
@@ -77,6 +77,7 @@ pub mod bitcoin {
     pub struct GetBalanceRequest {
         pub network: BitcoinNetwork,
         pub address_type: BitcoinAddressType,
+        pub min_confirmations: Option<u32>,
     }
 
     #[derive(CandidType, Deserialize, Debug)]

--- a/src/signer/canister/signer.did
+++ b/src/signer/canister/signer.did
@@ -72,6 +72,11 @@ type GetAddressRequest = record {
   address_type : BitcoinAddressType;
 };
 type GetAddressResponse = record { address : text };
+type GetBalanceRequest = record {
+  network : BitcoinNetwork;
+  address_type : BitcoinAddressType;
+  min_confirmations : opt nat32;
+};
 type GetBalanceResponse = record { balance : nat64 };
 type HttpRequest = record {
   url : text;
@@ -203,7 +208,7 @@ type WithdrawFromError = variant {
 };
 service : (Arg) -> {
   btc_caller_address : (GetAddressRequest, opt PaymentType) -> (Result);
-  btc_caller_balance : (GetAddressRequest, opt PaymentType) -> (Result_1);
+  btc_caller_balance : (GetBalanceRequest, opt PaymentType) -> (Result_1);
   btc_caller_send : (SendBtcRequest, opt PaymentType) -> (Result_2);
   caller_eth_address : () -> (text);
   config : () -> (Config) query;

--- a/src/signer/canister/src/lib.rs
+++ b/src/signer/canister/src/lib.rs
@@ -338,7 +338,7 @@ async fn btc_caller_balance(
                     .await
                     .map_err(|msg| GetBalanceError::InternalError { msg })?;
 
-            let balance = bitcoin_api::get_balance(params.network, address)
+            let balance = bitcoin_api::get_balance(params.network, address, params.min_confirmations)
                 .await
                 .map_err(|msg| GetBalanceError::InternalError { msg })?;
 

--- a/src/signer/canister/src/lib.rs
+++ b/src/signer/canister/src/lib.rs
@@ -338,9 +338,10 @@ async fn btc_caller_balance(
                     .await
                     .map_err(|msg| GetBalanceError::InternalError { msg })?;
 
-            let balance = bitcoin_api::get_balance(params.network, address, params.min_confirmations)
-                .await
-                .map_err(|msg| GetBalanceError::InternalError { msg })?;
+            let balance =
+                bitcoin_api::get_balance(params.network, address, params.min_confirmations)
+                    .await
+                    .map_err(|msg| GetBalanceError::InternalError { msg })?;
 
             Ok(GetBalanceResponse { balance })
         }

--- a/src/signer/canister/src/sign/bitcoin/bitcoin_api.rs
+++ b/src/signer/canister/src/sign/bitcoin/bitcoin_api.rs
@@ -8,8 +8,7 @@ use ic_cdk::api::management_canister::bitcoin::{
 ///
 /// Relies on the `bitcoin_get_balance` endpoint.
 /// See [Bitcoin API](https://internetcomputer.org/docs/current/references/ic-interface-spec/#ic-bitcoin_get_balance)
-pub async fn get_balance(network: BitcoinNetwork, address: String) -> Result<u64, String> {
-    let min_confirmations = None;
+pub async fn get_balance(network: BitcoinNetwork, address: String, min_confirmations: Option<u32>) -> Result<u64, String> {
     let balance_res = bitcoin_get_balance(GetBalanceRequest {
         address,
         network,

--- a/src/signer/canister/src/sign/bitcoin/bitcoin_api.rs
+++ b/src/signer/canister/src/sign/bitcoin/bitcoin_api.rs
@@ -8,7 +8,11 @@ use ic_cdk::api::management_canister::bitcoin::{
 ///
 /// Relies on the `bitcoin_get_balance` endpoint.
 /// See [Bitcoin API](https://internetcomputer.org/docs/current/references/ic-interface-spec/#ic-bitcoin_get_balance)
-pub async fn get_balance(network: BitcoinNetwork, address: String, min_confirmations: Option<u32>) -> Result<u64, String> {
+pub async fn get_balance(
+    network: BitcoinNetwork,
+    address: String,
+    min_confirmations: Option<u32>,
+) -> Result<u64, String> {
     let balance_res = bitcoin_get_balance(GetBalanceRequest {
         address,
         network,

--- a/src/signer/canister/tests/it/bitcoin.rs
+++ b/src/signer/canister/tests/it/bitcoin.rs
@@ -17,6 +17,7 @@ fn test_caller_btc_balance() {
     let params = GetBalanceRequest {
         network,
         address_type: BitcoinAddressType::P2WPKH,
+        min_confirmations: None,
     };
 
     let balance_response = pic_setup


### PR DESCRIPTION
# Motivation

The bitcoin balance depends on the transactions in the blockchain, and the transactions go over a certain amount of confirmations.

We want to enable clients to query the bitcoin balance of the desired confirmations threshold.

# Changes

* Add new parameter `min_confirmations` to `GetBalanceRequest`.
* Add new parameter `min_confirmations` in `get_balance`.
* Use new parameter from request to get bitcoin balance in `btc_caller_balance` endpoint.
* New field in candid file.

# Tests

* Add new parameter in the test for bitcoin balance.
