### PR TITLE
fix(devops): Helpful message when nightly rust formatter is not installed

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -23,6 +23,7 @@ jobs:
         run: npm ci --no-audit
       - name: Install nightly rust
         run: |
+          # Note: These commands should be the same as in the help message in scripts/fmt-rs
           rustup toolchain install nightly
           rustup component add rustfmt --toolchain nightly
       - name: Format

--- a/scripts/fmt-rs
+++ b/scripts/fmt-rs
@@ -2,4 +2,16 @@
 set -euxo pipefail
 cd "$(dirname "$(realpath "$0")")/.."
 
+# Checks that the required toolchain is installed
+rustup component list --toolchain nightly | grep -q rustfmt || {
+
+	echo "ERROR: The nightly rust formatter is not installed."
+	echo "       Please install with:"
+	echo "       rustup toolchain install nightly"
+        echo "       rustup component add rustfmt --toolchain nightly"
+	echo "ABORTING..."
+	exit 1
+} >&2
+
+
 cargo +nightly fmt

--- a/scripts/fmt-rs
+++ b/scripts/fmt-rs
@@ -7,6 +7,7 @@ rustup component list --toolchain nightly | grep -q rustfmt || {
 
 	echo "ERROR: The nightly rust formatter is not installed."
 	echo "       Please install with:"
+	# Note: These install commands should match the equivalent commands in CI.
 	echo "       rustup toolchain install nightly"
         echo "       rustup component add rustfmt --toolchain nightly"
 	echo "ABORTING..."

--- a/scripts/fmt-rs
+++ b/scripts/fmt-rs
@@ -5,14 +5,13 @@ cd "$(dirname "$(realpath "$0")")/.."
 # Checks that the required toolchain is installed
 rustup component list --toolchain nightly | grep -q rustfmt || {
 
-	echo "ERROR: The nightly rust formatter is not installed."
-	echo "       Please install with:"
-	# Note: These install commands should match the equivalent commands in CI.
-	echo "       rustup toolchain install nightly"
-        echo "       rustup component add rustfmt --toolchain nightly"
-	echo "ABORTING..."
-	exit 1
+  echo "ERROR: The nightly rust formatter is not installed."
+  echo "       Please install with:"
+  # Note: These install commands should match the equivalent commands in CI.
+  echo "       rustup toolchain install nightly"
+  echo "       rustup component add rustfmt --toolchain nightly"
+  echo "ABORTING..."
+  exit 1
 } >&2
-
 
 cargo +nightly fmt


### PR DESCRIPTION
# Motivation
If the nightly rust formatter is not installed, formatting fails with an obscure message.

# Changes
- Provide a helpful error message with instructions for how to install the nightly rust formatter
- Add comments to try to ensure that the help message stays in sync with the install commands used in CI.

# Tests
We need some new developers to confuse...

See CI for the happy path.