### PR TITLE
refactor(signer): Rename field in EthSignPrehash

### DIFF
--- a/src/signer/api/src/types/eth.rs
+++ b/src/signer/api/src/types/eth.rs
@@ -107,7 +107,7 @@ impl From<(RejectionCode, String)> for EthPersonalSignError {
 
 #[derive(CandidType, Deserialize, Debug, Clone)]
 pub struct EthSignPrehashRequest {
-    pub message: String,
+    pub hash: String,
 }
 #[derive(CandidType, Deserialize, Debug, Clone)]
 pub struct EthSignPrehashResponse {

--- a/src/signer/canister/signer.did
+++ b/src/signer/canister/signer.did
@@ -51,7 +51,7 @@ type EthAddressRequest = record { "principal" : opt principal };
 type EthAddressResponse = record { address : text };
 type EthPersonalSignRequest = record { message : text };
 type EthPersonalSignResponse = record { signature : text };
-type EthSignPrehashRequest = record { message : text };
+type EthSignPrehashRequest = record { hash : text };
 type EthSignPrehashResponse = record { signature : text };
 type EthSignTransactionRequest = record {
   to : text;

--- a/src/signer/canister/src/lib.rs
+++ b/src/signer/canister/src/lib.rs
@@ -244,7 +244,7 @@ async fn eth_sign_prehash(
         .await?;
 
     Ok(EthSignPrehashResponse {
-        signature: eth::sign_prehash(req.message).await,
+        signature: eth::sign_prehash(req.hash).await,
     })
 }
 


### PR DESCRIPTION
# Motivation
The `SignPrehashRequest` argument calls the prehash "message".  This could get awfully confusing.  It would be best to rectify this before the API is in use.

# Changes
- Rename the field.

# Tests
Existing tests should suffice.