### PR TITLE
feat(signer): Correct pricing

### DIFF
--- a/scripts/check-pricing
+++ b/scripts/check-pricing
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+DFX_NETWORK="${1:-staging}"
+SIGNER_CANISTER_ID="$(dfx canister id --network "$DFX_NETWORK" signer)"
+CYCLES_LEDGER_CANISTER_ID="$(dfx canister id --network "$DFX_NETWORK" cycles_ledger)"
+
+to_number() {
+  : Converts symbols such as 1K to 1_000
+  numfmt --from=si | rev | sed 's/.../&_/g' | rev
+}
+signer_balance() {
+  dfx canister status --network "$DFX_NETWORK" signer | awk '($1 == "Balance:"){print $2}'
+}
+check_call_pricing() {
+  local before after
+  before="$(signer_balance)"
+  dfx canister call --network "$DFX_NETWORK" signer "${@}" >/dev/null
+  after="$(signer_balance)"
+  diff="$(echo "$after - $before" | tr -d _ | bc)"
+  if [[ $diff = -* ]]; then
+    echo "WARNING: signer balance fell by $diff for: $1"
+  else
+    echo "OK: Signer balance rose by $diff for: $1"
+  fi
+}
+
+APPROVAL="1P"
+
+: Approve funds for use in the test
+dfx canister call cycles_ledger icrc2_approve --network "$DFX_NETWORK" "
+  record {
+    amount = $(echo "$APPROVAL" | to_number);
+    spender = record {
+      owner = principal \"${SIGNER_CANISTER_ID}\";
+    };
+  }" >/dev/null
+
+: Check that each method is making a profit
+
+check_call_pricing btc_caller_address '
+(
+  record { network = variant { mainnet }; address_type = variant { P2WPKH } },
+  opt variant { CallerPaysIcrc2Cycles },
+)
+'
+check_call_pricing btc_caller_balance '
+
+(
+  record { network = variant { mainnet }; address_type = variant { P2WPKH } },
+  opt variant { CallerPaysIcrc2Cycles },
+)
+'
+check_call_pricing btc_caller_send '
+(
+  record {
+    fee_satoshis = null;
+    network = variant { mainnet };
+    utxos_to_spend = vec {};
+    address_type = variant { P2WPKH };
+    outputs = vec {};
+  },
+  opt variant { CallerPaysIcrc2Cycles },
+)
+'
+check_call_pricing eth_address '
+(
+  record {},
+  opt variant { CallerPaysIcrc2Cycles },
+)
+'
+check_call_pricing eth_personal_sign '
+(
+  record { message = "1234123412341234123412341234123412341234123412341234123412341234123412341234123412341234123412341234123412341234123412341234" },
+  opt variant { CallerPaysIcrc2Cycles },
+)
+'
+check_call_pricing eth_sign_prehash '(record { hash = "0123456701234567012345670123456701234567012345670123456701234567" }, opt variant { CallerPaysIcrc2Cycles })'
+check_call_pricing eth_sign_transaction '
+(
+  record {
+    to = "0x5e9F1cAF942aa8Ee887B75f5A6bCCaf4B1024248";
+    gas = 999 : nat;
+    value = 3 : nat;
+    max_priority_fee_per_gas = 23_645_624_464 : nat;
+    data = opt "0x02f86783aa36a7808203158201c87b945e9f1caf942aa8ee887b75f5a6bccaf4b10242480180c080a02fc93932ea116781baffa2f5e62079772c2d6ed91219caff433f653a6e657460a0301f525ac8a55602cc4bddb8c714c2be08aa2bf43fb0ddad974aa4f589d505b9";
+    max_fee_per_gas = 888 : nat;
+    chain_id = 4 : nat;
+    nonce = 6 : nat;
+  },
+  opt variant { CallerPaysIcrc2Cycles },
+)
+'
+check_call_pricing generic_caller_ecdsa_public_key '
+(
+  record {
+    key_id = record { name = "key_1"; curve = variant { secp256k1 } };
+    canister_id = null;
+    derivation_path = vec { blob "foo"; blob "bar"; blob "bat" };
+  },
+  opt variant { CallerPaysIcrc2Cycles },
+)
+'
+check_call_pricing generic_sign_with_ecdsa '
+(
+  opt variant { CallerPaysIcrc2Cycles },
+  record {
+    key_id = record { name = "key_1"; curve = variant { secp256k1 } };
+    derivation_path = vec { blob "foo"; blob "bar"; blob "bat" };
+    message_hash = blob "\41\40\f0\a8\8b\3e\ea\41\5c\d2\77\4f\c2\70\f1\6b\51\2c\7c\63\7e\9b\54\2a\31\35\96\8b\ac\b1\47\ae";
+  },
+)
+'

--- a/scripts/check-pricing
+++ b/scripts/check-pricing
@@ -13,7 +13,16 @@ print_help() {
 
 	Note: Measurement is affected by other API calls made to the network.
 
-	Usage: "$(basename "$0")" [network]
+	Usage: "$(basename "$0")" [network] [method_name_pattern]
+	where:
+	  'network' is a dfx network name.
+	     Default: ic
+	  'method_name_pattern' is a regular expression; only API methods
+	     matching the pattern will be tested.
+	     Default: All methods.
+	Example:
+	  "$(basename "$0")" ic btc
+	     will check pricing for all bitcoin methods.
 	EOF
 }
 
@@ -23,6 +32,7 @@ print_help() {
 }
 
 DFX_NETWORK="${1:-ic}"
+METHOD_NAME_PATTERN="${2:-.}"
 SIGNER_CANISTER_ID="$(dfx canister id --network "$DFX_NETWORK" signer)"
 
 to_number() {
@@ -34,6 +44,10 @@ signer_balance() {
 }
 check_call_pricing() {
   local before after
+  echo "$1" | grep -qE "$METHOD_NAME_PATTERN" || {
+    echo "Skipping $1..."
+    return
+  }
   before="$(signer_balance)"
   dfx canister call --network "$DFX_NETWORK" signer "${@}" >/dev/null
   after="$(signer_balance)"
@@ -76,9 +90,30 @@ check_call_pricing btc_caller_send '
   record {
     fee_satoshis = null;
     network = variant { mainnet };
-    utxos_to_spend = vec {};
+    utxos_to_spend = vec {
+      record {
+        height = 9_876_543 : nat32;
+        value = 12_345_667_890 : nat64;
+        outpoint = record { txid = blob "\36\f3\a7\fc\b6\b5\eb\d9\fa\40\41\92\8d\a8\9c\d4\23\66\2f\9c\5c\12\e4\1c\80\e0\7a\65\59\d1\78\ef"; vout = 12_345_678 : nat32 };
+      };
+      record {
+        height = 9_876_543 : nat32;
+        value = 12_345_667_890 : nat64;
+        outpoint = record { txid = blob "\d3\f7\1b\58\d5\39\fd\97\d2\12\2f\11\2d\52\da\db\6a\47\9a\d3\c4\74\64\97\8b\3b\0c\e0\04\6c\1b\50"; vout = 12_345_678 : nat32 };
+      };
+      record {
+        height = 9_876_543 : nat32;
+        value = 12_345_667_890 : nat64;
+        outpoint = record { txid = blob "\62\79\11\13\aa\4b\f3\39\e7\2a\fc\a3\7c\99\96\0e\0e\29\24\09\16\b6\5e\2b\24\5a\8a\7b\9e\ff\cd\eb"; vout = 12_345_678 : nat32 };
+      };
+    };
     address_type = variant { P2WPKH };
-    outputs = vec {};
+    outputs = vec {
+      record {
+        destination_address = "funplace";
+        sent_satoshis = 23_456_789 : nat64;
+      };
+    };
   },
   opt variant { CallerPaysIcrc2Cycles },
 )

--- a/scripts/check-pricing
+++ b/scripts/check-pricing
@@ -1,9 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-DFX_NETWORK="${1:-staging}"
+DFX_NETWORK="${1:-ic}"
 SIGNER_CANISTER_ID="$(dfx canister id --network "$DFX_NETWORK" signer)"
-CYCLES_LEDGER_CANISTER_ID="$(dfx canister id --network "$DFX_NETWORK" cycles_ledger)"
 
 to_number() {
   : Converts symbols such as 1K to 1_000

--- a/scripts/check-pricing
+++ b/scripts/check-pricing
@@ -42,6 +42,12 @@ to_number() {
 signer_balance() {
   dfx canister status --network "$DFX_NETWORK" signer | awk '($1 == "Balance:"){print $2}'
 }
+add_underscores_to_number() {
+  rev | sed -E 's/.../&_/g;s/_(-?)$/\1/g' | rev
+}
+remove_underscores() {
+  tr -d _
+}
 check_call_pricing() {
   local before after
   echo "$1" | grep -qE "$METHOD_NAME_PATTERN" || {
@@ -51,7 +57,7 @@ check_call_pricing() {
   before="$(signer_balance)"
   dfx canister call --network "$DFX_NETWORK" signer "${@}" >/dev/null
   after="$(signer_balance)"
-  diff="$(echo "$after - $before" | tr -d _ | bc)"
+  diff="$(echo "$after - $before" | remove_underscores | bc | add_underscores_to_number)"
   if [[ $diff = -* ]]; then
     echo "WARNING: signer balance fell by $diff for: $1"
   else
@@ -110,7 +116,7 @@ check_call_pricing btc_caller_send '
     address_type = variant { P2WPKH };
     outputs = vec {
       record {
-        destination_address = "funplace";
+        destination_address = "bc1qxy2kgdygjrsqtzq2n0yrf2493p83kkfjhx0wlh";
         sent_satoshis = 23_456_789 : nat64;
       };
     };

--- a/scripts/check-pricing
+++ b/scripts/check-pricing
@@ -1,6 +1,27 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+print_help() {
+  cat <<-EOF
+	Checks that API pricing covers cycle costs.
+
+	For each API method, this:
+	* Gets the signer canister cycles balance
+	* Makes a sample API call
+	* Gets the cycles balance again
+	* Reports on the difference.
+
+	Note: Measurement is affected by other API calls made to the network.
+
+	Usage: "$(basename "$0")" [network]
+	EOF
+}
+
+[[ "${1:-}" != "--help" ]] || {
+  print_help
+  exit 0
+}
+
 DFX_NETWORK="${1:-ic}"
 SIGNER_CANISTER_ID="$(dfx canister id --network "$DFX_NETWORK" signer)"
 

--- a/scripts/did.sh
+++ b/scripts/did.sh
@@ -1,8 +1,9 @@
 #!/usr/bin/env bash
 
 function generate_did() {
-  local canister=$1
-  local candid_file="$(canister="$canister" jq -r .canisters[env.canister].candid dfx.json)"
+  local canister candid_file;
+  canister=$1
+  candid_file="$(canister="$canister" jq -r '.canisters[env.canister].candid' dfx.json)"
 
   test -e "target/wasm32-unknown-unknown/release/$canister.wasm" ||
     cargo build \

--- a/scripts/did.sh
+++ b/scripts/did.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 function generate_did() {
-  local canister candid_file;
+  local canister candid_file
   canister=$1
   candid_file="$(canister="$canister" jq -r '.canisters[env.canister].candid' dfx.json)"
 

--- a/src/signer/canister/src/lib.rs
+++ b/src/signer/canister/src/lib.rs
@@ -117,7 +117,7 @@ async fn generic_caller_ecdsa_public_key(
     arg: EcdsaPublicKeyArgument,
     payment: Option<PaymentType>,
 ) -> Result<(EcdsaPublicKeyResponse,), GenericCallerEcdsaPublicKeyError> {
-    let fee = 1_000_000_000;
+    let fee = 1_000_000_000; // Determined with the aid of scripts/check-pricing
     PAYMENT_GUARD
         .deduct(
             PaymentContext::default(),
@@ -134,7 +134,7 @@ async fn generic_sign_with_ecdsa(
     payment: Option<PaymentType>,
     arg: SignWithEcdsaArgument,
 ) -> Result<(SignWithEcdsaResponse,), GenericSignWithEcdsaError> {
-    let fee = 40_000_000_000;
+    let fee = 40_000_000_000; // Determined with the aid of scripts/check-pricing
     PAYMENT_GUARD
         .deduct(
             PaymentContext::default(),
@@ -166,7 +166,7 @@ async fn eth_address(
         .deduct(
             PaymentContext::default(),
             payment.unwrap_or(PaymentType::AttachedCycles),
-            1_000_000_000,
+            1_000_000_000, // Determined with the aid of scripts/check-pricing
         )
         .await?;
     eth::eth_address(principal).await
@@ -186,7 +186,7 @@ async fn eth_address_of_caller(
         .deduct(
             PaymentContext::default(),
             payment.unwrap_or(PaymentType::AttachedCycles),
-            1_000_000_000,
+            1_000_000_000, // Determined with the aid of scripts/check-pricing
         )
         .await?;
     eth::eth_address(principal).await
@@ -202,7 +202,7 @@ async fn eth_sign_transaction(
         .deduct(
             PaymentContext::default(),
             payment.unwrap_or(PaymentType::AttachedCycles),
-            40_000_000_000,
+            40_000_000_000, // Determined with the aid of scripts/check-pricing
         )
         .await?;
     Ok(EthSignTransactionResponse {
@@ -220,7 +220,7 @@ async fn eth_personal_sign(
         .deduct(
             PaymentContext::default(),
             payment.unwrap_or(PaymentType::AttachedCycles),
-            40_000_000_000,
+            40_000_000_000, // Determined with the aid of scripts/check-pricing
         )
         .await?;
     Ok(EthPersonalSignResponse {
@@ -238,7 +238,7 @@ async fn eth_sign_prehash(
         .deduct(
             PaymentContext::default(),
             payment.unwrap_or(PaymentType::AttachedCycles),
-            40_000_000_000,
+            40_000_000_000, // Determined with the aid of scripts/check-pricing
         )
         .await?;
 
@@ -263,7 +263,7 @@ async fn btc_caller_address(
         .deduct(
             PaymentContext::default(),
             payment.unwrap_or(PaymentType::AttachedCycles),
-            20_000_000,
+            20_000_000,  // Determined with the aid of scripts/check-pricing
         )
         .await?;
     */
@@ -291,7 +291,7 @@ async fn btc_caller_balance(
         .deduct(
             PaymentContext::default(),
             payment.unwrap_or(PaymentType::AttachedCycles),
-            40_000_000,
+            40_000_000, // Determined with the aid of scripts/check-pricing
         )
         .await?;
     */
@@ -324,7 +324,7 @@ async fn btc_caller_send(
         .deduct(
             PaymentContext::default(),
             payment.unwrap_or(PaymentType::AttachedCycles),
-            130_000_000_000,
+            130_000_000_000, // Determined with the aid of scripts/check-pricing
         )
         .await?;
     */

--- a/src/signer/canister/src/lib.rs
+++ b/src/signer/canister/src/lib.rs
@@ -324,7 +324,7 @@ async fn btc_caller_send(
         .deduct(
             PaymentContext::default(),
             payment.unwrap_or(PaymentType::AttachedCycles),
-            40_000_000,
+            130_000_000_000,
         )
         .await?;
     */

--- a/src/signer/canister/src/lib.rs
+++ b/src/signer/canister/src/lib.rs
@@ -135,7 +135,7 @@ async fn generic_sign_with_ecdsa(
     payment: Option<PaymentType>,
     arg: SignWithEcdsaArgument,
 ) -> Result<(SignWithEcdsaResponse,), GenericSignWithEcdsaError> {
-    let fee = 1_000_000_000;
+    let fee = 40_000_000_000;
     PAYMENT_GUARD
         .deduct(
             PaymentContext::default(),
@@ -203,7 +203,7 @@ async fn eth_sign_transaction(
         .deduct(
             PaymentContext::default(),
             payment.unwrap_or(PaymentType::AttachedCycles),
-            1_000_000_000,
+            40_000_000_000,
         )
         .await?;
     Ok(EthSignTransactionResponse {
@@ -221,7 +221,7 @@ async fn eth_personal_sign(
         .deduct(
             PaymentContext::default(),
             payment.unwrap_or(PaymentType::AttachedCycles),
-            1_000_000_000,
+            40_000_000_000,
         )
         .await?;
     Ok(EthPersonalSignResponse {
@@ -239,7 +239,7 @@ async fn eth_sign_prehash(
         .deduct(
             PaymentContext::default(),
             payment.unwrap_or(PaymentType::AttachedCycles),
-            1_000_000_000,
+            40_000_000_000,
         )
         .await?;
 
@@ -299,7 +299,7 @@ async fn btc_caller_address(
         .deduct(
             PaymentContext::default(),
             payment.unwrap_or(PaymentType::AttachedCycles),
-            1_000_000_000,
+            20_000_000,
         )
         .await?;
     */
@@ -327,7 +327,7 @@ async fn btc_caller_balance(
         .deduct(
             PaymentContext::default(),
             payment.unwrap_or(PaymentType::AttachedCycles),
-            1_000_000_000,
+            40_000_000,
         )
         .await?;
     */
@@ -359,7 +359,7 @@ async fn btc_caller_send(
         .deduct(
             PaymentContext::default(),
             payment.unwrap_or(PaymentType::AttachedCycles),
-            1_000_000_000,
+            40_000_000,
         )
         .await?;
     */


### PR DESCRIPTION
# Motivation
The price set for most API methods was well below the actual mainnet cost.

Note: The cycle cost depends on the size of the subnet and the number of cycles consumed.  The pricing also needs to cover requests in which payment failed.

# Changes
- Add a command that creates a payment report.
- Update the API prices to about 150% of the cycle cost.
  - Note: We can  fine tune the prices later.

TODO: Extract subnet size as a variable and write a test that:
- Checks that the ic deployment subnet size hasn't changed (note: this may potentially change without notice)
- Checks that the cycle cost per subnet node is correct.

# Tests
After deploying to mainnet, the pricing report should mark every price as OK.