### PR TITLE
feat(devops): Fix the cycles ledger canister ID

### DIFF
--- a/dfx.json
+++ b/dfx.json
@@ -37,6 +37,7 @@
 			"candid": "https://github.com/dfinity/cycles-ledger/releases/download/cycles-ledger-v1.0.1/cycles-ledger.did",
 			"wasm": "https://github.com/dfinity/cycles-ledger/releases/download/cycles-ledger-v1.0.1/cycles-ledger.wasm.gz",
 			"init_arg": "( variant { Init = record { index_id = null; max_blocks_per_request = 9_999 : nat64 }},)",
+			"specified_id": "um5iw-rqaaa-aaaaq-qaaba-cai",
 			"remote": {
 				"id": {
 					"staging": "um5iw-rqaaa-aaaaq-qaaba-cai",


### PR DESCRIPTION
# Motivation
To be able to use the same signer canister build in tests and prod, it is necessary to fix the ID of the cycles ledger.

# Changes
- In dfx, specify that the cycles ledger canister ID should match prod.

# Tests
