### PR TITLE
fix(devops): Lint shell scripts in ci

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -37,6 +37,16 @@ jobs:
                   git diff
                   exit 1
           }
+  sh-tests:
+    name: "Shell tests"
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Install tools
+        run: sudo apt-get install -yy shellcheck
+      - name: Lint shell
+        run: ./scripts/lint-sh
   rust-tests:
     name: "Rust tests"
     runs-on: ${{ matrix.os }}
@@ -107,7 +117,7 @@ jobs:
         run: dfx stop
   check-pass:
     name: "Checks pass"
-    needs: ["format", "rust-tests", "installation"]
+    needs: ["format", "rust-tests", "sh-tests", "installation"]
     if: ${{ always() }}
     runs-on: ubuntu-22.04
     steps:

--- a/scripts/commit-metadata
+++ b/scripts/commit-metadata
@@ -1,3 +1,6 @@
 #!/usr/bin/env bash
 : The commit and any semantic version tags to be stored in the canister metadata.
+
+# The $ in the single quotes is intentional; it matches the end of the file.
+# shellcheck disable=SC2016
 echo "$(git rev-parse HEAD)$(git tag -l --contains HEAD | sed -nE '/^v[0-9]/{s/^/ /g;H};${x;s/\n//g;p}')"

--- a/scripts/lint-sh
+++ b/scripts/lint-sh
@@ -20,7 +20,7 @@ filter() {
   while read -r line; do if [[ "$line" = *.sh ]] || file "$line" | grep -qw Bourne; then echo "$line"; fi; done
 }
 
-lint=(shellcheck -e SC1090 -e SC2119 -e SC1091)
+lint=(shellcheck -e SC1090 -e SC2119 -e SC1091 -e SC2016)
 
 case "${1:-}" in
 --help) print_help && exit 0 ;;

--- a/scripts/lint-sh
+++ b/scripts/lint-sh
@@ -20,7 +20,7 @@ filter() {
   while read -r line; do if [[ "$line" = *.sh ]] || file "$line" | grep -qw Bourne; then echo "$line"; fi; done
 }
 
-lint=(shellcheck -e SC1090 -e SC2119 -e SC1091 -e SC2016)
+lint=(shellcheck -e SC1090 -e SC2119 -e SC1091)
 
 case "${1:-}" in
 --help) print_help && exit 0 ;;


### PR DESCRIPTION
# Motivation
The shell linter is not currently run in CI.  This means that fixing shell lints can require changes to a PR unrelated to the PR.

# Changes
- Add a job to CI that runs shfmt.

# Tests
See CI