### PR TITLE
fix(devops): Run prebuild in GitHub

### DIFF
--- a/.github/actions/build/action.yaml
+++ b/.github/actions/build/action.yaml
@@ -13,6 +13,7 @@ runs:
     - name: Set up docker buildx
       uses: docker/setup-buildx-action@v3
     - name: Prepare for the docker build
+      shell: bash
       run: scripts/docker-build.pre
     - name: Build wasms
       uses: docker/build-push-action@v5

--- a/.github/actions/build/action.yaml
+++ b/.github/actions/build/action.yaml
@@ -12,6 +12,8 @@ runs:
   steps:
     - name: Set up docker buildx
       uses: docker/setup-buildx-action@v3
+    - name: Prepare for the docker build
+      run: scripts/docker-build.pre
     - name: Build wasms
       uses: docker/build-push-action@v5
       with:

--- a/scripts/docker-build
+++ b/scripts/docker-build
@@ -42,8 +42,7 @@ if [[ "${1:-}" == "--help" ]]; then
   exit 0
 fi
 
-mkdir -p target
-scripts/commit-metadata >target/commit
+scripts/docker-build.pre
 
 if DOCKER_BUILDKIT=1 docker build \
   --target "$DFX_TARGET" \

--- a/scripts/docker-build.pre
+++ b/scripts/docker-build.pre
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+# Commands run before calling docker.
+# This is used both in command line docker builds and in CI docker builds (that are called in a different way)
+
+set -euxo pipefail
+mkdir -p target
+scripts/commit-metadata >target/commit


### PR DESCRIPTION
# Motivation
The docker wasm build in GitHub is failing because the step where the commit is put into a file for docker to consume is run in `scripts/docker-build` only, and not in the GitHub docker run.

# Changes
- Move the pre-docker steps into a dedicated script and call them from both `docker-build` and GitHub.

# Tests
Pushing the release tag should work with these changes.