### PR TITLE
fix(signer): Require payment everywhere

### DIFF
--- a/src/signer/canister/src/lib.rs
+++ b/src/signer/canister/src/lib.rs
@@ -247,7 +247,7 @@ async fn btc_caller_address(
     PAYMENT_GUARD
         .deduct(
             payment.unwrap_or(PaymentType::AttachedCycles),
-            20_000_000,  // Determined with the aid of scripts/check-pricing
+            20_000_000, // Determined with the aid of scripts/check-pricing
         )
         .await?;
     match params.address_type {

--- a/src/signer/canister/src/lib.rs
+++ b/src/signer/canister/src/lib.rs
@@ -244,15 +244,12 @@ async fn btc_caller_address(
     params: GetAddressRequest,
     payment: Option<PaymentType>, // Note: Do NOT use underscore, please, so that the underscore doesn't show up in the generated candid.
 ) -> Result<GetAddressResponse, GetAddressError> {
-    /* TODO: uncomment when the payment guard is ready
     PAYMENT_GUARD
         .deduct(
-            PaymentContext::default(),
             payment.unwrap_or(PaymentType::AttachedCycles),
             20_000_000,  // Determined with the aid of scripts/check-pricing
         )
         .await?;
-    */
     match params.address_type {
         BitcoinAddressType::P2WPKH => {
             let address =


### PR DESCRIPTION
# Motivation
When enabling payment for all endpoints, I missed one: `btc_caller_address`

# Changes
- Uncomment the payment checks for `btc_caller_address`

# Tests
Existing tests should suffice.  Tests still need to be updated though!