### PR TITLE
refactor(devops): Move formatting into an action

### DIFF
--- a/.github/actions/format/action.yaml
+++ b/.github/actions/format/action.yaml
@@ -1,0 +1,21 @@
+name: 'Formats the code'
+description: |
+  Formats all the code in the repository
+runs:
+  using: "composite"
+  steps:
+    - name: Install tools
+      shell: bash
+      run: ./scripts/setup cargo-binstall shfmt yq cargo-sort
+    - name: Install node dependencies
+      shell: bash
+      run: npm ci --no-audit
+    - name: Install nightly rust
+      shell: bash
+      run: |
+        # Note: These commands should be the same as in the help message in scripts/fmt-rs
+        rustup toolchain install nightly
+        rustup component add rustfmt --toolchain nightly
+    - name: Format
+      shell: bash
+      run: ./scripts/fmt

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -17,17 +17,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Install tools
-        run: ./scripts/setup cargo-binstall shfmt yq cargo-sort
-      - name: Install node dependencies
-        run: npm ci --no-audit
-      - name: Install nightly rust
-        run: |
-          # Note: These commands should be the same as in the help message in scripts/fmt-rs
-          rustup toolchain install nightly
-          rustup component add rustfmt --toolchain nightly
-      - name: Format
-        run: ./scripts/fmt
+      - name: Format code
+        uses: ./.github/actions/format
       - name: Ignore some changes
         run: while read -r line ; do git checkout "$line" ; done <.relaxedfmt
       - name: Check formatted


### PR DESCRIPTION
# Motivation
After generating bindings, it is necessary to format.

# Changes
- Move the GitHub formatting code into an action so that it can be reused.

# Tests
See CI