### PR TITLE
test(signer): Extend the pic canister trait

### DIFF
--- a/dfx.json
+++ b/dfx.json
@@ -32,6 +32,7 @@
 		"example_backend": {
 			"candid": "src/example_backend/example_backend.did",
 			"package": "example_backend",
+			"gzip": true,
 			"type": "rust"
 		},
 		"example_frontend": {

--- a/src/signer/canister/signer.did
+++ b/src/signer/canister/signer.did
@@ -102,6 +102,7 @@ type PaymentError = variant {
     ledger : principal;
   };
   LedgerUnreachable : CallerPaysIcrc2Tokens;
+  InvalidPatron;
   LedgerTransferFromError : record {
     error : TransferFromError;
     ledger : principal;
@@ -161,16 +162,6 @@ type SendBtcRequest = record {
   outputs : vec BtcTxOutput;
 };
 type SendBtcResponse = record { txid : text };
-type SignRequest = record {
-  to : text;
-  gas : nat;
-  value : nat;
-  max_priority_fee_per_gas : nat;
-  data : opt text;
-  max_fee_per_gas : nat;
-  chain_id : nat;
-  nonce : nat;
-};
 type SignWithEcdsaArgument = record {
   key_id : EcdsaKeyId;
   derivation_path : vec blob;
@@ -210,10 +201,8 @@ service : (Arg) -> {
   btc_caller_address : (GetAddressRequest, opt PaymentType) -> (Result);
   btc_caller_balance : (GetBalanceRequest, opt PaymentType) -> (Result_1);
   btc_caller_send : (SendBtcRequest, opt PaymentType) -> (Result_2);
-  caller_eth_address : () -> (text);
   config : () -> (Config) query;
   eth_address : (EthAddressRequest, opt PaymentType) -> (Result_3);
-  eth_address_of : (principal) -> (text);
   eth_address_of_caller : (opt PaymentType) -> (Result_3);
   eth_personal_sign : (EthPersonalSignRequest, opt PaymentType) -> (Result_4);
   eth_sign_prehash : (EthSignPrehashRequest, opt PaymentType) -> (Result_5);
@@ -229,7 +218,4 @@ service : (Arg) -> {
     );
   get_canister_status : () -> (CanisterStatusResultV2);
   http_request : (HttpRequest) -> (HttpResponse) query;
-  personal_sign : (text) -> (text);
-  sign_prehash : (text) -> (text);
-  sign_transaction : (SignRequest) -> (text);
 }

--- a/src/signer/canister/signer.did
+++ b/src/signer/canister/signer.did
@@ -102,7 +102,6 @@ type PaymentError = variant {
     ledger : principal;
   };
   LedgerUnreachable : CallerPaysIcrc2Tokens;
-  InvalidPatron;
   LedgerTransferFromError : record {
     error : TransferFromError;
     ledger : principal;
@@ -162,6 +161,16 @@ type SendBtcRequest = record {
   outputs : vec BtcTxOutput;
 };
 type SendBtcResponse = record { txid : text };
+type SignRequest = record {
+  to : text;
+  gas : nat;
+  value : nat;
+  max_priority_fee_per_gas : nat;
+  data : opt text;
+  max_fee_per_gas : nat;
+  chain_id : nat;
+  nonce : nat;
+};
 type SignWithEcdsaArgument = record {
   key_id : EcdsaKeyId;
   derivation_path : vec blob;
@@ -201,8 +210,10 @@ service : (Arg) -> {
   btc_caller_address : (GetAddressRequest, opt PaymentType) -> (Result);
   btc_caller_balance : (GetBalanceRequest, opt PaymentType) -> (Result_1);
   btc_caller_send : (SendBtcRequest, opt PaymentType) -> (Result_2);
+  caller_eth_address : () -> (text);
   config : () -> (Config) query;
   eth_address : (EthAddressRequest, opt PaymentType) -> (Result_3);
+  eth_address_of : (principal) -> (text);
   eth_address_of_caller : (opt PaymentType) -> (Result_3);
   eth_personal_sign : (EthPersonalSignRequest, opt PaymentType) -> (Result_4);
   eth_sign_prehash : (EthSignPrehashRequest, opt PaymentType) -> (Result_5);
@@ -218,4 +229,7 @@ service : (Arg) -> {
     );
   get_canister_status : () -> (CanisterStatusResultV2);
   http_request : (HttpRequest) -> (HttpResponse) query;
+  personal_sign : (text) -> (text);
+  sign_prehash : (text) -> (text);
+  sign_transaction : (SignRequest) -> (text);
 }

--- a/src/signer/canister/tests/it/address.rs
+++ b/src/signer/canister/tests/it/address.rs
@@ -3,8 +3,9 @@ use crate::utils::{
         CALLER, CALLER_BTC_ADDRESS_MAINNET, CALLER_BTC_ADDRESS_REGTEST, CALLER_BTC_ADDRESS_TESTNET,
         CALLER_ETH_ADDRESS,
     },
-    pocketic::{setup, PicCanisterTrait},
+    pocketic::{setup},
 };
+use crate::utils::pic_canister::PicCanisterTrait;
 use candid::Principal;
 use ic_cdk::api::management_canister::bitcoin::BitcoinNetwork;
 use ic_chain_fusion_signer_api::types::bitcoin::{

--- a/src/signer/canister/tests/it/address.rs
+++ b/src/signer/canister/tests/it/address.rs
@@ -3,9 +3,9 @@ use crate::utils::{
         CALLER, CALLER_BTC_ADDRESS_MAINNET, CALLER_BTC_ADDRESS_REGTEST, CALLER_BTC_ADDRESS_TESTNET,
         CALLER_ETH_ADDRESS,
     },
-    pocketic::{setup},
+    pic_canister::PicCanisterTrait,
+    pocketic::setup,
 };
-use crate::utils::pic_canister::PicCanisterTrait;
 use candid::Principal;
 use ic_cdk::api::management_canister::bitcoin::BitcoinNetwork;
 use ic_chain_fusion_signer_api::types::bitcoin::{

--- a/src/signer/canister/tests/it/bitcoin.rs
+++ b/src/signer/canister/tests/it/bitcoin.rs
@@ -1,12 +1,13 @@
 use crate::utils::{
     mock::CALLER,
-    pocketic::{setup, PicCanisterTrait},
+    pocketic::{setup},
 };
 use candid::Principal;
 use ic_cdk::api::management_canister::bitcoin::BitcoinNetwork;
 use ic_chain_fusion_signer_api::types::bitcoin::{
     BitcoinAddressType, GetBalanceError, GetBalanceRequest, GetBalanceResponse,
 };
+use crate::utils::pic_canister::PicCanisterTrait;
 
 #[ignore] // TODO: Update this test
 #[test]

--- a/src/signer/canister/tests/it/bitcoin.rs
+++ b/src/signer/canister/tests/it/bitcoin.rs
@@ -1,13 +1,9 @@
-use crate::utils::{
-    mock::CALLER,
-    pocketic::{setup},
-};
+use crate::utils::{mock::CALLER, pic_canister::PicCanisterTrait, pocketic::setup};
 use candid::Principal;
 use ic_cdk::api::management_canister::bitcoin::BitcoinNetwork;
 use ic_chain_fusion_signer_api::types::bitcoin::{
     BitcoinAddressType, GetBalanceError, GetBalanceRequest, GetBalanceResponse,
 };
-use crate::utils::pic_canister::PicCanisterTrait;
 
 #[ignore] // TODO: Update this test
 #[test]

--- a/src/signer/canister/tests/it/sign.rs
+++ b/src/signer/canister/tests/it/sign.rs
@@ -1,8 +1,8 @@
 use crate::utils::{
     mock::{CALLER, CALLER_ETH_ADDRESS, SEPOLIA_CHAIN_ID},
-    pocketic::{setup},
+    pic_canister::PicCanisterTrait,
+    pocketic::setup,
 };
-use crate::utils::pic_canister::PicCanisterTrait;
 use candid::{Nat, Principal};
 use ic_chain_fusion_signer_api::types::transaction::SignRequest;
 

--- a/src/signer/canister/tests/it/sign.rs
+++ b/src/signer/canister/tests/it/sign.rs
@@ -1,7 +1,8 @@
 use crate::utils::{
     mock::{CALLER, CALLER_ETH_ADDRESS, SEPOLIA_CHAIN_ID},
-    pocketic::{setup, PicCanisterTrait},
+    pocketic::{setup},
 };
+use crate::utils::pic_canister::PicCanisterTrait;
 use candid::{Nat, Principal};
 use ic_chain_fusion_signer_api::types::transaction::SignRequest;
 

--- a/src/signer/canister/tests/it/utils/mod.rs
+++ b/src/signer/canister/tests/it/utils/mod.rs
@@ -1,2 +1,3 @@
 pub mod mock;
 pub mod pocketic;
+pub mod pic_canister;

--- a/src/signer/canister/tests/it/utils/mod.rs
+++ b/src/signer/canister/tests/it/utils/mod.rs
@@ -1,3 +1,3 @@
 pub mod mock;
-pub mod pocketic;
 pub mod pic_canister;
+pub mod pocketic;

--- a/src/signer/canister/tests/it/utils/pic_canister.rs
+++ b/src/signer/canister/tests/it/utils/pic_canister.rs
@@ -60,41 +60,40 @@ pub trait PicCanisterTrait {
             })
     }
 }
-    fn workspace_dir() -> PathBuf {
-        let output = std::process::Command::new(env!("CARGO"))
-            .arg("locate-project")
-            .arg("--workspace")
-            .arg("--message-format=plain")
-            .output()
-            .unwrap()
-            .stdout;
-        let cargo_path = Path::new(std::str::from_utf8(&output).unwrap().trim());
-        cargo_path.parent().unwrap().to_path_buf()
-    }
-    /// The path to a typical Cargo Wasm build.
-    #[allow(dead_code)]
-    fn cargo_wasm_path(name: &str) -> String {
-        let workspace_dir = workspace_dir();
-        workspace_dir
-            .join("target/wasm32-unknown-unknown/release")
-            .join(name)
-            .with_extension("wasm")
-            .to_str()
-            .unwrap()
-            .to_string()
-    }
-    /// The path to the wasm after `dfx deploy`.  Expects the Wasm to be gzipped.
-    ///
-    /// If not already gzipped, please add this to the canister declaration in `dfx.json`: `"gzip": true`
-    #[allow(dead_code)]
-    fn dfx_wasm_path(name: &str) -> String {
-        workspace_dir()
-            .join(format!(".dfx/local/canisters/{name}/{name}.wasm.gz"))
-            .to_str()
-            .unwrap()
-            .to_string()
-    }
-
+fn workspace_dir() -> PathBuf {
+    let output = std::process::Command::new(env!("CARGO"))
+        .arg("locate-project")
+        .arg("--workspace")
+        .arg("--message-format=plain")
+        .output()
+        .unwrap()
+        .stdout;
+    let cargo_path = Path::new(std::str::from_utf8(&output).unwrap().trim());
+    cargo_path.parent().unwrap().to_path_buf()
+}
+/// The path to a typical Cargo Wasm build.
+#[allow(dead_code)]
+fn cargo_wasm_path(name: &str) -> String {
+    let workspace_dir = workspace_dir();
+    workspace_dir
+        .join("target/wasm32-unknown-unknown/release")
+        .join(name)
+        .with_extension("wasm")
+        .to_str()
+        .unwrap()
+        .to_string()
+}
+/// The path to the wasm after `dfx deploy`.  Expects the Wasm to be gzipped.
+///
+/// If not already gzipped, please add this to the canister declaration in `dfx.json`: `"gzip": true`
+#[allow(dead_code)]
+fn dfx_wasm_path(name: &str) -> String {
+    workspace_dir()
+        .join(format!(".dfx/local/canisters/{name}/{name}.wasm.gz"))
+        .to_str()
+        .unwrap()
+        .to_string()
+}
 
 /// A typical canister running on PocketIC.
 pub struct PicCanister {
@@ -198,9 +197,9 @@ impl Default for PicCanisterBuilder {
 }
 // Customisation
 impl PicCanisterBuilder {
-     /// Create a new canister builder.
-     #[allow(dead_code)]
-     fn new(name: &str) -> Self {
+    /// Create a new canister builder.
+    #[allow(dead_code)]
+    fn new(name: &str) -> Self {
         Self {
             canister_name: Some(name.to_string()),
             canister_id: None,
@@ -245,10 +244,7 @@ impl PicCanisterBuilder {
 impl PicCanisterBuilder {
     /// Reads the Wasm bytes from the configured path.
     fn wasm_bytes(&self) -> Vec<u8> {
-        fs::read(self.wasm_path.clone()).expect(&format!(
-            "Could not find wasm: {}",
-            self.wasm_path
-        ))
+        fs::read(self.wasm_path.clone()).expect(&format!("Could not find wasm: {}", self.wasm_path))
     }
 }
 // Builder
@@ -303,7 +299,6 @@ impl PicCanisterBuilder {
     }
 }
 
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -318,7 +313,8 @@ mod tests {
     impl Default for MulticanisterTestEnv {
         fn default() -> Self {
             let example_backend = PicCanisterBuilder::new("example_backend").deploy();
-            let cycles_depositor = PicCanisterBuilder::new("cycles_depositor").deploy_to(example_backend.pic());
+            let cycles_depositor =
+                PicCanisterBuilder::new("cycles_depositor").deploy_to(example_backend.pic());
             Self {
                 example_backend,
                 cycles_depositor,

--- a/src/signer/canister/tests/it/utils/pic_canister.rs
+++ b/src/signer/canister/tests/it/utils/pic_canister.rs
@@ -307,7 +307,7 @@ mod tests {
     use super::*;
     #[test]
     fn can_deploy_canister() {
-        let _pic = PicCanisterBuilder::new("example_backend").deploy();
+        let _simple_single_canister_test_env = PicCanisterBuilder::new("example_backend").deploy();
     }
     struct MulticanisterTestEnv {
         #[allow(dead_code)] // Created in tests.

--- a/src/signer/canister/tests/it/utils/pic_canister.rs
+++ b/src/signer/canister/tests/it/utils/pic_canister.rs
@@ -312,15 +312,15 @@ mod tests {
         let _pic = PicCanisterBuilder::new("example_backend").deploy();
     }
     struct MulticanisterTestEnv {
-        pub cycles_ledger: PicCanister,
+        pub example_backend: PicCanister,
         pub cycles_depositor: PicCanister,
     }
     impl Default for MulticanisterTestEnv {
         fn default() -> Self {
-            let cycles_ledger = PicCanisterBuilder::new("cycles_ledger").deploy();
-            let cycles_depositor = PicCanisterBuilder::new("cycles_depositor").deploy_to(cycles_ledger.pic());
+            let example_backend = PicCanisterBuilder::new("example_backend").deploy();
+            let cycles_depositor = PicCanisterBuilder::new("cycles_depositor").deploy_to(example_backend.pic());
             Self {
-                cycles_ledger,
+                example_backend,
                 cycles_depositor,
             }
         }

--- a/src/signer/canister/tests/it/utils/pic_canister.rs
+++ b/src/signer/canister/tests/it/utils/pic_canister.rs
@@ -307,17 +307,20 @@ mod tests {
         let _pic = PicCanisterBuilder::new("example_backend").deploy();
     }
     struct MulticanisterTestEnv {
+        #[allow(dead_code)] // Created in tests.
         pub example_backend: PicCanister,
-        pub cycles_depositor: PicCanister,
+        #[allow(dead_code)] // Created in tests.
+        pub example_frontend: PicCanister,
     }
     impl Default for MulticanisterTestEnv {
         fn default() -> Self {
             let example_backend = PicCanisterBuilder::new("example_backend").deploy();
-            let cycles_depositor =
-                PicCanisterBuilder::new("cycles_depositor").deploy_to(example_backend.pic());
+            // Deploy the frontend to the same pic:
+            let pic = example_backend.pic();
+            let example_frontend = PicCanisterBuilder::new("example_frontend").deploy_to(pic);
             Self {
                 example_backend,
-                cycles_depositor,
+                example_frontend,
             }
         }
     }

--- a/src/signer/canister/tests/it/utils/pic_canister.rs
+++ b/src/signer/canister/tests/it/utils/pic_canister.rs
@@ -134,14 +134,15 @@ impl PicCanister {
 /// To add a canister to an existing `PocketIC`:
 /// ```
 /// let pic = PocketIc::new();
-/// let canister_id = PicCanisterBuilder::default().deploy_to(&pic);
+/// let canister_id = PicCanisterBuilder::new("my_canister_name").deploy_to(&pic);
 /// ```
 /// To redeploy an existing canister:
 /// ```
 /// // First deployment:
-/// let pic_canister = PicCanisterBuilder::default().deploy();
+/// let first = PicCanisterBuilder::new("my_canister_name").deploy();
+/// let canister_id = first.canister_id();
 /// // Subsequent deployment:
-/// let canister_id = PicCanisterBuilder::default().with_canister(canister_id).deploy_to(&pic);
+/// let canister_id = PicCanisterBuilder::new("my_canister_name").with_canister(canister_id).deploy_to(&pic);
 /// ```
 /// To customise the deployment, use the `.with_*` modifiers.  E.g.:
 /// ```
@@ -198,7 +199,7 @@ impl Default for PicCanisterBuilder {
 // Customisation
 impl PicCanisterBuilder {
     /// Create a new canister builder.
-    /// 
+    ///
     /// The canister name is used to find the .wasm.gz used in the local dfx deployment.
     #[allow(dead_code)]
     fn new(name: &str) -> Self {

--- a/src/signer/canister/tests/it/utils/pic_canister.rs
+++ b/src/signer/canister/tests/it/utils/pic_canister.rs
@@ -198,6 +198,8 @@ impl Default for PicCanisterBuilder {
 // Customisation
 impl PicCanisterBuilder {
     /// Create a new canister builder.
+    /// 
+    /// The canister name is used to find the .wasm.gz used in the local dfx deployment.
     #[allow(dead_code)]
     fn new(name: &str) -> Self {
         Self {

--- a/src/signer/canister/tests/it/utils/pic_canister.rs
+++ b/src/signer/canister/tests/it/utils/pic_canister.rs
@@ -126,23 +126,23 @@ impl PicCanister {
 /// # Example
 /// For a default test environment:
 /// ```
-/// let pic_canister = BackendBuilder::default().deploy();
+/// let pic_canister = PicCanisterBuilder::default().deploy();
 /// ```
-/// To add a backend canister to an existing `PocketIC`:
+/// To add a canister to an existing `PocketIC`:
 /// ```
 /// let pic = PocketIc::new();
-/// let canister_id = BackendBuilder::default().deploy_to(&pic);
+/// let canister_id = PicCanisterBuilder::default().deploy_to(&pic);
 /// ```
 /// To redeploy an existing canister:
 /// ```
 /// // First deployment:
-/// let (pic, canister_id) = BackendBuilder::default().deploy();
+/// let (pic, canister_id) = PicCanisterBuilder::default().deploy();
 /// // Subsequent deployment:
-/// let canister_id = BackendBuilder::default().with_canister(canister_id).deploy_to(&pic);
+/// let canister_id = PicCanisterBuilder::default().with_canister(canister_id).deploy_to(&pic);
 /// ```
 /// To customise the deployment, use the `.with_*` modifiers.  E.g.:
 /// ```
-/// let (pic, canister_id) = BackendBuilder::default()
+/// let (pic, canister_id) = PicCanisterBuilder::default()
 ///    .with_wasm("path/to/ic_chainfusion_signer.wasm")
 ///    .with_arg(vec![1, 2, 3])
 ///    .with_controllers(vec![Principal::from_text("controller").unwrap()])
@@ -151,26 +151,26 @@ impl PicCanister {
 /// ```
 #[derive(Debug)]
 pub struct PicCanisterBuilder {
-    /// Canister ID of the backend canister.  If not set, a new canister will be created.
+    /// Canister ID of the canister.  If not set, a new canister will be created.
     canister_id: Option<Principal>,
-    /// Cycles to add to the backend canister.
+    /// Cycles to add to the canister.
     cycles: u128,
-    /// Path to the backend wasm file.
+    /// Path to the wasm file.
     wasm_path: String,
-    /// Argument to pass to the backend canister.
+    /// Argument to pass to the canister.
     arg: Vec<u8>,
-    /// Controllers of the backend canister.
+    /// Controllers of the canister.
     ///
     /// If the list is not specified, controllers will be unchnaged from the PocketIc defaults.
     controllers: Option<Vec<Principal>>,
 }
 // Defaults
 impl PicCanisterBuilder {
-    /// The default number of cycles to add to the backend canister on deployment.
+    /// The default number of cycles to add to the canister on deployment.
     ///
     /// To override, please use `with_cycles()`.
     pub const DEFAULT_CYCLES: u128 = 2_000_000_000_000;
-    /// The default argument to pass to the backend canister:  `()`.
+    /// The default argument to pass to the canister:  `()`.
     ///
     /// To override, please use `with_arg()`.
     pub fn default_arg() -> Vec<u8> {
@@ -190,7 +190,7 @@ impl Default for PicCanisterBuilder {
 }
 // Customisation
 impl PicCanisterBuilder {
-    /// Sets a custom argument for the backend canister.
+    /// Sets a custom argument for the canister.
     #[allow(dead_code)]
     pub fn with_arg(mut self, arg: Vec<u8>) -> Self {
         self.arg = arg;
@@ -202,13 +202,13 @@ impl PicCanisterBuilder {
         self.canister_id = Some(canister_id);
         self
     }
-    /// Sets custom controllers for the backend canister.
+    /// Sets custom controllers for the canister.
     #[allow(dead_code)]
     pub fn with_controllers(mut self, controllers: Vec<Principal>) -> Self {
         self.controllers = Some(controllers);
         self
     }
-    /// Sets the cycles to add to the backend canister.
+    /// Sets the cycles to add to the canister.
     #[allow(dead_code)]
     pub fn with_cycles(mut self, cycles: u128) -> Self {
         self.cycles = cycles;
@@ -223,10 +223,10 @@ impl PicCanisterBuilder {
 }
 // Get parameters
 impl PicCanisterBuilder {
-    /// Reads the backend Wasm bytes from the configured path.
+    /// Reads the Wasm bytes from the configured path.
     fn wasm_bytes(&self) -> Vec<u8> {
         fs::read(self.wasm_path.clone()).expect(&format!(
-            "Could not find the backend wasm: {}",
+            "Could not find wasm: {}",
             self.wasm_path
         ))
     }
@@ -243,21 +243,21 @@ impl PicCanisterBuilder {
             canister_id
         }
     }
-    /// Add cycles to the backend canister.
+    /// Add cycles to the canister.
     fn add_cycles(&mut self, pic: &PocketIc) {
         if self.cycles > 0 {
             let canister_id = self.canister_id(pic);
             pic.add_cycles(canister_id, self.cycles);
         }
     }
-    /// Install the backend canister.
+    /// Install the canister.
     fn install(&mut self, pic: &PocketIc) {
         let wasm_bytes = self.wasm_bytes();
         let canister_id = self.canister_id(pic);
         let arg = self.arg.clone();
         pic.install_canister(canister_id, wasm_bytes, arg, None);
     }
-    /// Set controllers of the backend canister.
+    /// Set controllers of the canister.
     fn set_controllers(&mut self, pic: &PocketIc) {
         if let Some(controllers) = self.controllers.clone() {
             let canister_id = self.canister_id(pic);
@@ -265,7 +265,7 @@ impl PicCanisterBuilder {
                 .expect("Test setup error: Failed to set controllers");
         }
     }
-    /// Setup the backend canister.
+    /// Setup the canister.
     pub fn deploy_to(&mut self, pic: Arc<PocketIc>) -> PicCanister {
         let canister_id = self.canister_id(&pic);
         self.add_cycles(&pic);

--- a/src/signer/canister/tests/it/utils/pic_canister.rs
+++ b/src/signer/canister/tests/it/utils/pic_canister.rs
@@ -1,0 +1,279 @@
+//! Common methods for interacting with a canister using `PocketIc`.
+use candid::{decode_one, encode_one, CandidType, Deserialize, Principal};
+use pocket_ic::{PocketIc, WasmResult};
+use std::{
+    fs,
+    path::{Path, PathBuf},
+    sync::Arc,
+};
+
+/// Common methods for interacting with a canister using `PocketIc`.
+pub trait PicCanisterTrait {
+    /// A shared PocketIc instance.
+    ///
+    /// Note: `PocketIc` uses interior mutability for query and update calls.  No external mut annotation or locks appear to be necessary.
+    fn pic(&self) -> Arc<PocketIc>;
+
+    /// The ID of this canister.
+    fn canister_id(&self) -> Principal;
+
+    /// Makes an update call to the canister.
+    fn update<T>(&self, caller: Principal, method: &str, arg: impl CandidType) -> Result<T, String>
+    where
+        T: for<'a> Deserialize<'a> + CandidType,
+    {
+        self.pic()
+            .update_call(self.canister_id(), caller, method, encode_one(arg).unwrap())
+            .map_err(|e| {
+                format!(
+                    "Update call error. RejectionCode: {:?}, Error: {}",
+                    e.code, e.description
+                )
+            })
+            .and_then(|reply| match reply {
+                WasmResult::Reply(reply) => {
+                    decode_one(&reply).map_err(|e| format!("Decoding failed: {e}"))
+                }
+                WasmResult::Reject(error) => Err(error),
+            })
+    }
+
+    /// Makes a query call to the canister.
+    #[allow(dead_code)]
+    fn query<T>(&self, caller: Principal, method: &str, arg: impl CandidType) -> Result<T, String>
+    where
+        T: for<'a> Deserialize<'a> + CandidType,
+    {
+        self.pic()
+            .query_call(self.canister_id(), caller, method, encode_one(arg).unwrap())
+            .map_err(|e| {
+                format!(
+                    "Query call error. RejectionCode: {:?}, Error: {}",
+                    e.code, e.description
+                )
+            })
+            .and_then(|reply| match reply {
+                WasmResult::Reply(reply) => {
+                    decode_one(&reply).map_err(|_| "Decoding failed".to_string())
+                }
+                WasmResult::Reject(error) => Err(error),
+            })
+    }
+    fn workspace_dir() -> PathBuf {
+        let output = std::process::Command::new(env!("CARGO"))
+            .arg("locate-project")
+            .arg("--workspace")
+            .arg("--message-format=plain")
+            .output()
+            .unwrap()
+            .stdout;
+        let cargo_path = Path::new(std::str::from_utf8(&output).unwrap().trim());
+        cargo_path.parent().unwrap().to_path_buf()
+    }
+    /// The path to a typical Cargo Wasm build.
+    #[allow(dead_code)]
+    fn cargo_wasm_path(name: &str) -> String {
+        let workspace_dir = Self::workspace_dir();
+        workspace_dir
+            .join("target/wasm32-unknown-unknown/release")
+            .join(name)
+            .with_extension("wasm")
+            .to_str()
+            .unwrap()
+            .to_string()
+    }
+    /// The path to the wasm after `dfx deploy`.  Expects the Wasm to be gzipped.
+    ///
+    /// If not already gzipped, please add this to the canister declaration in `dfx.json`: `"gzip": true`
+    #[allow(dead_code)]
+    fn dfx_wasm_path(name: &str) -> String {
+        Self::workspace_dir()
+            .join(format!(".dfx/local/canisters/{name}/{name}.wasm.gz"))
+            .to_str()
+            .unwrap()
+            .to_string()
+    }
+}
+
+/// A typical canister running on PocketIC.
+pub struct PicCanister {
+    pub pic: Arc<PocketIc>,
+    pub canister_id: Principal,
+}
+
+impl PicCanisterTrait for PicCanister {
+    /// The shared PocketIc instance.
+    fn pic(&self) -> Arc<PocketIc> {
+        self.pic.clone()
+    }
+    /// The ID of this canister.
+    fn canister_id(&self) -> Principal {
+        self.canister_id.clone()
+    }
+}
+
+impl PicCanister {
+    /// Creates a new canister.
+    pub fn new(pic: Arc<PocketIc>, wasm_path: &str) -> Self {
+        PicCanisterBuilder::default()
+            .with_wasm(wasm_path)
+            .deploy_to(pic)
+    }
+}
+
+/// Canister installer, using the builder pattern, for use in test environmens using `PocketIC`.
+///
+/// # Example
+/// For a default test environment:
+/// ```
+/// let pic_canister = BackendBuilder::default().deploy();
+/// ```
+/// To add a backend canister to an existing `PocketIC`:
+/// ```
+/// let pic = PocketIc::new();
+/// let canister_id = BackendBuilder::default().deploy_to(&pic);
+/// ```
+/// To redeploy an existing canister:
+/// ```
+/// // First deployment:
+/// let (pic, canister_id) = BackendBuilder::default().deploy();
+/// // Subsequent deployment:
+/// let canister_id = BackendBuilder::default().with_canister(canister_id).deploy_to(&pic);
+/// ```
+/// To customise the deployment, use the `.with_*` modifiers.  E.g.:
+/// ```
+/// let (pic, canister_id) = BackendBuilder::default()
+///    .with_wasm("path/to/ic_chainfusion_signer.wasm")
+///    .with_arg(vec![1, 2, 3])
+///    .with_controllers(vec![Principal::from_text("controller").unwrap()])
+///    .with_cycles(1_000_000_000_000)
+///    .deploy();
+/// ```
+#[derive(Debug)]
+pub struct PicCanisterBuilder {
+    /// Canister ID of the backend canister.  If not set, a new canister will be created.
+    canister_id: Option<Principal>,
+    /// Cycles to add to the backend canister.
+    cycles: u128,
+    /// Path to the backend wasm file.
+    wasm_path: String,
+    /// Argument to pass to the backend canister.
+    arg: Vec<u8>,
+    /// Controllers of the backend canister.
+    ///
+    /// If the list is not specified, controllers will be unchnaged from the PocketIc defaults.
+    controllers: Option<Vec<Principal>>,
+}
+// Defaults
+impl PicCanisterBuilder {
+    /// The default number of cycles to add to the backend canister on deployment.
+    ///
+    /// To override, please use `with_cycles()`.
+    pub const DEFAULT_CYCLES: u128 = 2_000_000_000_000;
+    /// The default argument to pass to the backend canister:  `()`.
+    ///
+    /// To override, please use `with_arg()`.
+    pub fn default_arg() -> Vec<u8> {
+        encode_one(()).unwrap()
+    }
+}
+impl Default for PicCanisterBuilder {
+    fn default() -> Self {
+        Self {
+            canister_id: None,
+            cycles: Self::DEFAULT_CYCLES,
+            wasm_path: "unspecified.wasm".to_string(),
+            arg: Self::default_arg(),
+            controllers: None,
+        }
+    }
+}
+// Customisation
+impl PicCanisterBuilder {
+    /// Sets a custom argument for the backend canister.
+    #[allow(dead_code)]
+    pub fn with_arg(mut self, arg: Vec<u8>) -> Self {
+        self.arg = arg;
+        self
+    }
+    /// Deploys to an existing canister with the given ID.
+    #[allow(dead_code)]
+    pub fn with_canister(mut self, canister_id: Principal) -> Self {
+        self.canister_id = Some(canister_id);
+        self
+    }
+    /// Sets custom controllers for the backend canister.
+    #[allow(dead_code)]
+    pub fn with_controllers(mut self, controllers: Vec<Principal>) -> Self {
+        self.controllers = Some(controllers);
+        self
+    }
+    /// Sets the cycles to add to the backend canister.
+    #[allow(dead_code)]
+    pub fn with_cycles(mut self, cycles: u128) -> Self {
+        self.cycles = cycles;
+        self
+    }
+    /// Configures the deployment to use a custom Wasm file.
+    #[allow(dead_code)]
+    pub fn with_wasm(mut self, wasm_path: &str) -> Self {
+        self.wasm_path = wasm_path.to_string();
+        self
+    }
+}
+// Get parameters
+impl PicCanisterBuilder {
+    /// Reads the backend Wasm bytes from the configured path.
+    fn wasm_bytes(&self) -> Vec<u8> {
+        fs::read(self.wasm_path.clone()).expect(&format!(
+            "Could not find the backend wasm: {}",
+            self.wasm_path
+        ))
+    }
+}
+// Builder
+impl PicCanisterBuilder {
+    /// Get or create canister.
+    fn canister_id(&mut self, pic: &PocketIc) -> Principal {
+        if let Some(canister_id) = self.canister_id {
+            canister_id
+        } else {
+            let canister_id = pic.create_canister();
+            self.canister_id = Some(canister_id);
+            canister_id
+        }
+    }
+    /// Add cycles to the backend canister.
+    fn add_cycles(&mut self, pic: &PocketIc) {
+        if self.cycles > 0 {
+            let canister_id = self.canister_id(pic);
+            pic.add_cycles(canister_id, self.cycles);
+        }
+    }
+    /// Install the backend canister.
+    fn install(&mut self, pic: &PocketIc) {
+        let wasm_bytes = self.wasm_bytes();
+        let canister_id = self.canister_id(pic);
+        let arg = self.arg.clone();
+        pic.install_canister(canister_id, wasm_bytes, arg, None);
+    }
+    /// Set controllers of the backend canister.
+    fn set_controllers(&mut self, pic: &PocketIc) {
+        if let Some(controllers) = self.controllers.clone() {
+            let canister_id = self.canister_id(pic);
+            pic.set_controllers(canister_id.clone(), None, controllers)
+                .expect("Test setup error: Failed to set controllers");
+        }
+    }
+    /// Setup the backend canister.
+    pub fn deploy_to(&mut self, pic: Arc<PocketIc>) -> PicCanister {
+        let canister_id = self.canister_id(&pic);
+        self.add_cycles(&pic);
+        self.install(&pic);
+        self.set_controllers(&pic);
+        PicCanister {
+            pic: pic.clone(),
+            canister_id,
+        }
+    }
+}

--- a/src/signer/canister/tests/it/utils/pocketic.rs
+++ b/src/signer/canister/tests/it/utils/pocketic.rs
@@ -2,6 +2,7 @@ use candid::{decode_one, encode_one, CandidType, Principal};
 use ic_cdk::api::management_canister::bitcoin::BitcoinNetwork;
 use ic_chain_fusion_signer_api::types::{Arg, InitArg};
 use pocket_ic::{CallError, PocketIc, PocketIcBuilder, WasmResult};
+use crate::utils::pic_canister::PicCanisterTrait;
 use serde::Deserialize;
 use std::{
     env,
@@ -366,59 +367,5 @@ impl PicCanisterTrait for PicSigner {
     }
     fn canister_id(&self) -> Principal {
         self.canister_id.clone()
-    }
-}
-
-/// Common methods for interacting with a canister using `PocketIc`.
-pub trait PicCanisterTrait {
-    /// A shared PocketIc instance.
-    ///
-    /// Note: `PocketIc` uses interior mutability for query and update calls.  No external mut annotation or locks appear to be necessary.
-    fn pic(&self) -> Arc<PocketIc>;
-
-    /// The ID of this canister.
-    fn canister_id(&self) -> Principal;
-
-    /// Makes an update call to the canister.
-    fn update<T>(&self, caller: Principal, method: &str, arg: impl CandidType) -> Result<T, String>
-    where
-        T: for<'a> Deserialize<'a> + CandidType,
-    {
-        self.pic()
-            .update_call(self.canister_id(), caller, method, encode_one(arg).unwrap())
-            .map_err(|e| {
-                format!(
-                    "Update call error. RejectionCode: {:?}, Error: {}",
-                    e.code, e.description
-                )
-            })
-            .and_then(|reply| match reply {
-                WasmResult::Reply(reply) => {
-                    decode_one(&reply).map_err(|e| format!("Decoding failed: {e}"))
-                }
-                WasmResult::Reject(error) => Err(error),
-            })
-    }
-
-    /// Makes a query call to the canister.
-    #[allow(dead_code)]
-    fn query<T>(&self, caller: Principal, method: &str, arg: impl CandidType) -> Result<T, String>
-    where
-        T: for<'a> Deserialize<'a> + CandidType,
-    {
-        self.pic()
-            .query_call(self.canister_id(), caller, method, encode_one(arg).unwrap())
-            .map_err(|e| {
-                format!(
-                    "Query call error. RejectionCode: {:?}, Error: {}",
-                    e.code, e.description
-                )
-            })
-            .and_then(|reply| match reply {
-                WasmResult::Reply(reply) => {
-                    decode_one(&reply).map_err(|_| "Decoding failed".to_string())
-                }
-                WasmResult::Reject(error) => Err(error),
-            })
     }
 }

--- a/src/signer/canister/tests/it/utils/pocketic.rs
+++ b/src/signer/canister/tests/it/utils/pocketic.rs
@@ -1,8 +1,8 @@
+use crate::utils::pic_canister::PicCanisterTrait;
 use candid::{encode_one, CandidType, Principal};
 use ic_cdk::api::management_canister::bitcoin::BitcoinNetwork;
 use ic_chain_fusion_signer_api::types::{Arg, InitArg};
 use pocket_ic::{CallError, PocketIc, PocketIcBuilder};
-use crate::utils::pic_canister::PicCanisterTrait;
 use std::{
     env,
     fs::read,

--- a/src/signer/canister/tests/it/utils/pocketic.rs
+++ b/src/signer/canister/tests/it/utils/pocketic.rs
@@ -1,9 +1,8 @@
-use candid::{decode_one, encode_one, CandidType, Principal};
+use candid::{encode_one, CandidType, Principal};
 use ic_cdk::api::management_canister::bitcoin::BitcoinNetwork;
 use ic_chain_fusion_signer_api::types::{Arg, InitArg};
-use pocket_ic::{CallError, PocketIc, PocketIcBuilder, WasmResult};
+use pocket_ic::{CallError, PocketIc, PocketIcBuilder};
 use crate::utils::pic_canister::PicCanisterTrait;
-use serde::Deserialize;
 use std::{
     env,
     fs::read,


### PR DESCRIPTION
# Motivation
The pocket_ic canister tests will need to manage multiple canisters, not just one.  The utilities used to do this, to date, only support one canister.

# Changes
- Move the PicCanister trait into a separate file and add more methods to it.
- Create a more general version of the canister builder, suitable for use with multiple canisters.

# Tests
This is used in tests in the `papi` branch, but I am merging this separately to keep the PRs small and reviewable.