### PR TITLE
feat(devops): Add command to print the deployed version of all signers

### DIFF
--- a/scripts/report
+++ b/scripts/report
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+[[ "${1:-}" != "--help" ]] || {
+  cat <<-EOF
+	Prints which versions of the signer are deployed where and with what arguments.
+
+	Usage: $(basename "$0") [DFX_NETWORK]
+	EOF
+
+	exit 0
+}
+
+report_git_ref() {
+  dfx canister metadata signer git_commit_id --network "$DFX_NETWORK"
+}
+report_args() {
+  dfx canister call signer config --network "$DFX_NETWORK"
+}
+hrule() {
+  echo "########################################"
+}
+report() {
+  hrule
+  echo "network: $DFX_NETWORK"
+  echo "git ref: $(report_git_ref)"
+  echo "args:"
+  report_args
+  echo
+}
+
+readarray -t NETWORKS < <(jq -r '.signer | keys | .[]' canister_ids.json)
+
+for DFX_NETWORK in "${1:-${NETWORKS[@]}}" ; do
+  report
+done

--- a/scripts/report
+++ b/scripts/report
@@ -5,7 +5,7 @@ set -euo pipefail
   cat <<-EOF
 	Prints which versions of the signer are deployed where and with what arguments.
 
-	Usage: $(basename "$0") [DFX_NETWORK]
+	Usage: $(basename "$0") [DFX_NETWORK...]
 	EOF
 
   exit 0

--- a/scripts/report
+++ b/scripts/report
@@ -29,8 +29,11 @@ report() {
   echo
 }
 
-readarray -t NETWORKS < <(jq -r '.signer | keys | .[]' canister_ids.json)
+if (( $# > 0 ))
+then NETWORKS=("${@}")
+else readarray -t NETWORKS < <(jq -r '.signer | keys | .[]' canister_ids.json)
+fi
 
-for DFX_NETWORK in "${1:-${NETWORKS[@]}}" ; do
+for DFX_NETWORK in "${NETWORKS[@]}" ; do
   report
 done

--- a/scripts/report
+++ b/scripts/report
@@ -8,7 +8,7 @@ set -euo pipefail
 	Usage: $(basename "$0") [DFX_NETWORK]
 	EOF
 
-	exit 0
+  exit 0
 }
 
 report_git_ref() {
@@ -29,11 +29,12 @@ report() {
   echo
 }
 
-if (( $# > 0 ))
-then NETWORKS=("${@}")
-else readarray -t NETWORKS < <(jq -r '.signer | keys | .[]' canister_ids.json)
+if (($# > 0)); then
+  NETWORKS=("${@}")
+else
+  readarray -t NETWORKS < <(jq -r '.signer | keys | .[]' canister_ids.json)
 fi
 
-for DFX_NETWORK in "${NETWORKS[@]}" ; do
+for DFX_NETWORK in "${NETWORKS[@]}"; do
   report
 done


### PR DESCRIPTION
# Motivation
We need visibility of what is deployed where.

# Changes
- Add a command that lists the deployed version and arguments for each network.

# Tests
Run locally:
```
# List all deployed versions:
./scripts/report
...
# List one deployed version
./scripts/report staging
# List several deployed versions:
./scripts/report ic ic staging ic
```