### PR TITLE
refactor(signer): Rename update->update_one

### DIFF
--- a/scripts/bind/pic/cycles_depositor.hbs
+++ b/scripts/bind/pic/cycles_depositor.hbs
@@ -39,7 +39,7 @@ impl PicCanisterTrait for {{PascalCase canister_name}}Pic {
 impl {{PascalCase canister_name}}Pic {
   {{#each methods}}
   pub fn {{this.name}}(&self, _caller: Principal{{#each this.args}}, {{this.0}}: &{{this.1}}{{/each}}) -> Result<{{vec_to_arity this.rets}}, String> {
-      self.update(self.canister_id, "{{escape_debug this.original_name}}", arg0)
+      self.update_one(self.canister_id, "{{escape_debug this.original_name}}", arg0)
   }
   {{/each}}
 }

--- a/src/signer/canister/tests/it/address.rs
+++ b/src/signer/canister/tests/it/address.rs
@@ -20,7 +20,7 @@ fn test_caller_eth_address() {
     let caller = Principal::from_text(CALLER).unwrap();
 
     let address = pic_setup
-        .update::<String>(caller, "caller_eth_address", ())
+        .update_one::<String>(caller, "caller_eth_address", ())
         .expect("Failed to call eth address.");
 
     assert_eq!(address, CALLER_ETH_ADDRESS.to_string());
@@ -34,7 +34,7 @@ fn test_eth_address_of() {
     let caller = Principal::from_text(CALLER).unwrap();
 
     let address = pic_setup
-        .update::<String>(caller, "eth_address_of", caller)
+        .update_one::<String>(caller, "eth_address_of", caller)
         .expect("Failed to call eth address of.");
 
     assert_eq!(address, CALLER_ETH_ADDRESS.to_string());
@@ -45,7 +45,7 @@ fn test_eth_address_of() {
 fn test_anonymous_cannot_call_eth_address() {
     let pic_setup = setup();
 
-    let address = pic_setup.update::<String>(Principal::anonymous(), "caller_eth_address", ());
+    let address = pic_setup.update_one::<String>(Principal::anonymous(), "caller_eth_address", ());
 
     assert!(address.is_err());
     assert_eq!(
@@ -61,7 +61,7 @@ fn test_cannot_call_eth_address_of_for_anonymous() {
 
     let caller = Principal::from_text(CALLER).unwrap();
 
-    let address = pic_setup.update::<String>(caller, "eth_address_of", Principal::anonymous());
+    let address = pic_setup.update_one::<String>(caller, "eth_address_of", Principal::anonymous());
 
     assert!(address.is_err());
     assert!(address
@@ -82,7 +82,11 @@ fn test_caller_btc_address_mainnet() {
     };
 
     let address_response = pic_setup
-        .update::<Result<GetAddressResponse, GetAddressError>>(caller, "btc_caller_address", params)
+        .update_one::<Result<GetAddressResponse, GetAddressError>>(
+            caller,
+            "btc_caller_address",
+            params,
+        )
         .expect("Failed to call testnet btc address.")
         .expect("Failed to get successful response");
 
@@ -105,7 +109,11 @@ fn test_caller_btc_address_testnet() {
     };
 
     let address_response = pic_setup
-        .update::<Result<GetAddressResponse, GetAddressError>>(caller, "btc_caller_address", params)
+        .update_one::<Result<GetAddressResponse, GetAddressError>>(
+            caller,
+            "btc_caller_address",
+            params,
+        )
         .expect("Failed to call testnet btc address.")
         .expect("Failed to get successful response");
 
@@ -128,7 +136,11 @@ fn test_caller_btc_address_regtest() {
     };
 
     let address_response = pic_setup
-        .update::<Result<GetAddressResponse, GetAddressError>>(caller, "btc_caller_address", params)
+        .update_one::<Result<GetAddressResponse, GetAddressError>>(
+            caller,
+            "btc_caller_address",
+            params,
+        )
         .expect("Failed to call testnet btc address.")
         .expect("Failed to get successful response");
 
@@ -148,7 +160,8 @@ fn test_anonymous_cannot_call_btc_address() {
         address_type: BitcoinAddressType::P2WPKH,
     };
 
-    let address = pic_setup.update::<String>(Principal::anonymous(), "btc_caller_address", params);
+    let address =
+        pic_setup.update_one::<String>(Principal::anonymous(), "btc_caller_address", params);
 
     assert!(address.is_err());
     assert_eq!(
@@ -173,7 +186,7 @@ fn test_testnet_btc_address_is_not_same_as_regtest() {
     };
 
     let address_response_testnet = pic_setup
-        .update::<Result<GetAddressResponse, GetAddressError>>(
+        .update_one::<Result<GetAddressResponse, GetAddressError>>(
             caller,
             "btc_caller_address",
             params_testnet,
@@ -182,7 +195,7 @@ fn test_testnet_btc_address_is_not_same_as_regtest() {
         .expect("Failed to get successful response");
 
     let address_response_regtest = pic_setup
-        .update::<Result<GetAddressResponse, GetAddressError>>(
+        .update_one::<Result<GetAddressResponse, GetAddressError>>(
             caller,
             "btc_caller_address",
             params_regtest,

--- a/src/signer/canister/tests/it/bitcoin.rs
+++ b/src/signer/canister/tests/it/bitcoin.rs
@@ -19,7 +19,11 @@ fn test_caller_btc_balance() {
     };
 
     let balance_response = pic_setup
-        .update::<Result<GetBalanceResponse, GetBalanceError>>(caller, "btc_caller_balance", params)
+        .update_one::<Result<GetBalanceResponse, GetBalanceError>>(
+            caller,
+            "btc_caller_balance",
+            params,
+        )
         .expect("Failed to call testnet btc balance.")
         .expect("Failed to get successul balance response");
 

--- a/src/signer/canister/tests/it/canister/cycles_depositor.rs
+++ b/src/signer/canister/tests/it/canister/cycles_depositor.rs
@@ -55,6 +55,6 @@ impl PicCanisterTrait for CyclesDepositorPic {
 
 impl CyclesDepositorPic {
     pub fn deposit(&self, _caller: Principal, arg0: &DepositArg) -> Result<DepositResult, String> {
-        self.update(self.canister_id, "deposit", arg0)
+        self.update_one(self.canister_id, "deposit", arg0)
     }
 }

--- a/src/signer/canister/tests/it/sign.rs
+++ b/src/signer/canister/tests/it/sign.rs
@@ -24,7 +24,7 @@ fn test_sign_transaction() {
 
     let caller = Principal::from_text(CALLER).unwrap();
 
-    let transaction = pic_setup.update::<String>(caller, "sign_transaction", sign_request);
+    let transaction = pic_setup.update_one::<String>(caller, "sign_transaction", sign_request);
 
     assert_eq!(
         transaction.unwrap(),
@@ -39,7 +39,7 @@ fn test_personal_sign() {
 
     let caller = Principal::from_text(CALLER).unwrap();
 
-    let transaction = pic_setup.update::<String>(
+    let transaction = pic_setup.update_one::<String>(
         caller,
         "personal_sign",
         hex::encode("test message".to_string()),
@@ -58,7 +58,8 @@ fn test_cannot_personal_sign_if_message_is_not_hex_string() {
 
     let caller = Principal::from_text(CALLER).unwrap();
 
-    let result = pic_setup.update::<String>(caller, "personal_sign", "test message".to_string());
+    let result =
+        pic_setup.update_one::<String>(caller, "personal_sign", "test message".to_string());
 
     assert!(result.is_err());
     assert!(result.unwrap_err().contains("failed to decode hex"));
@@ -82,7 +83,7 @@ fn test_cannot_sign_transaction_with_invalid_to_address() {
 
     let caller = Principal::from_text(CALLER).unwrap();
 
-    let result = pic_setup.update::<String>(caller, "sign_transaction", sign_request);
+    let result = pic_setup.update_one::<String>(caller, "sign_transaction", sign_request);
 
     assert!(result.is_err());
     assert!(result
@@ -95,7 +96,7 @@ fn test_cannot_sign_transaction_with_invalid_to_address() {
 fn test_anonymous_cannot_sign_transaction() {
     let pic_setup = setup();
 
-    let result = pic_setup.update::<String>(Principal::anonymous(), "sign_transaction", ());
+    let result = pic_setup.update_one::<String>(Principal::anonymous(), "sign_transaction", ());
 
     assert!(result.is_err());
     assert_eq!(
@@ -109,7 +110,7 @@ fn test_anonymous_cannot_sign_transaction() {
 fn test_anonymous_cannot_personal_sign() {
     let pic_setup = setup();
 
-    let result = pic_setup.update::<String>(Principal::anonymous(), "personal_sign", ());
+    let result = pic_setup.update_one::<String>(Principal::anonymous(), "personal_sign", ());
 
     assert!(result.is_err());
     assert_eq!(

--- a/src/signer/canister/tests/it/utils/pic_canister.rs
+++ b/src/signer/canister/tests/it/utils/pic_canister.rs
@@ -18,7 +18,12 @@ pub trait PicCanisterTrait {
     fn canister_id(&self) -> Principal;
 
     /// Makes an update call to the canister.
-    fn update<T>(&self, caller: Principal, method: &str, arg: impl CandidType) -> Result<T, String>
+    fn update_one<T>(
+        &self,
+        caller: Principal,
+        method: &str,
+        arg: impl CandidType,
+    ) -> Result<T, String>
     where
         T: for<'a> Deserialize<'a> + CandidType,
     {


### PR DESCRIPTION
# Motivation
The `update()` utility used in `pocket_ic` tests only supports canister methods with a single argument and a single return value.  This is a common case but not the only one.

# Changes
- Rename `update(..)` to `update_one(..)`, to match functions such as `encode_one()` and `decode_one()`.  This makes space for `update()` to cover general update calls.

# Tests
Existing tests should suffice.