### PR TITLE
refactor(signer): Make fees accessible

### DIFF
--- a/src/signer/api/src/lib.rs
+++ b/src/signer/api/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod http;
 mod impls;
+pub mod methods;
 pub mod metrics;
 pub mod std_canister_status;
 pub mod types;

--- a/src/signer/api/src/methods.rs
+++ b/src/signer/api/src/methods.rs
@@ -12,16 +12,18 @@ pub enum SignerMethods {
 }
 
 impl SignerMethods {
+    /// The cost, in cycles, of every paid chain fusion signer API method.
+    #[must_use]
     pub fn fee(&self) -> u64 {
         // Note: Fees are determined with the aid of scripts/check-pricing
         match self {
-            SignerMethods::GenericCallerEcdsaPublicKey => 1_000_000_000,
-            SignerMethods::GenericSignWithEcdsa => 40_000_000_000,
-            SignerMethods::EthAddress => 1_000_000_000,
-            SignerMethods::EthAddressOfCaller => 1_000_000_000,
-            SignerMethods::EthSignTransaction => 40_000_000_000,
-            SignerMethods::EthPersonalSign => 40_000_000_000,
-            SignerMethods::EthSignPrehash => 40_000_000_000,
+            SignerMethods::GenericCallerEcdsaPublicKey
+            | SignerMethods::EthAddress
+            | SignerMethods::EthAddressOfCaller => 1_000_000_000,
+            SignerMethods::GenericSignWithEcdsa
+            | SignerMethods::EthSignTransaction
+            | SignerMethods::EthPersonalSign
+            | SignerMethods::EthSignPrehash => 40_000_000_000,
             SignerMethods::BtcCallerAddress => 20_000_000,
             SignerMethods::BtcCallerBalance => 40_000_000,
             SignerMethods::BtcCallerSend => 130_000_000_000,

--- a/src/signer/api/src/methods.rs
+++ b/src/signer/api/src/methods.rs
@@ -1,0 +1,30 @@
+pub enum SignerMethods {
+    GenericCallerEcdsaPublicKey,
+    GenericSignWithEcdsa,
+    EthAddress,
+    EthAddressOfCaller,
+    EthSignTransaction,
+    EthPersonalSign,
+    EthSignPrehash,
+    BtcCallerAddress,
+    BtcCallerBalance,
+    BtcCallerSend,
+}
+
+impl SignerMethods {
+    pub fn fee(&self) -> u64 {
+        // Note: Fees are determined with the aid of scripts/check-pricing
+        match self {
+            SignerMethods::GenericCallerEcdsaPublicKey => 1_000_000_000,
+            SignerMethods::GenericSignWithEcdsa => 40_000_000_000,
+            SignerMethods::EthAddress => 1_000_000_000,
+            SignerMethods::EthAddressOfCaller => 1_000_000_000,
+            SignerMethods::EthSignTransaction => 40_000_000_000,
+            SignerMethods::EthPersonalSign => 40_000_000_000,
+            SignerMethods::EthSignPrehash => 40_000_000_000,
+            SignerMethods::BtcCallerAddress => 20_000_000,
+            SignerMethods::BtcCallerBalance => 40_000_000,
+            SignerMethods::BtcCallerSend => 130_000_000_000,
+        }
+    }
+}

--- a/src/signer/canister/src/lib.rs
+++ b/src/signer/canister/src/lib.rs
@@ -6,6 +6,7 @@ use ic_cdk::api::management_canister::ecdsa::{
 use ic_cdk_macros::{export_candid, init, post_upgrade, query, update};
 use ic_chain_fusion_signer_api::{
     http::{HttpRequest, HttpResponse},
+    methods::SignerMethods,
     metrics::get_metrics,
     std_canister_status,
     types::{
@@ -116,9 +117,11 @@ async fn generic_caller_ecdsa_public_key(
     arg: EcdsaPublicKeyArgument,
     payment: Option<PaymentType>,
 ) -> Result<(EcdsaPublicKeyResponse,), GenericCallerEcdsaPublicKeyError> {
-    let fee = 1_000_000_000; // Determined with the aid of scripts/check-pricing
     PAYMENT_GUARD
-        .deduct(payment.unwrap_or(PaymentType::AttachedCycles), fee)
+        .deduct(
+            payment.unwrap_or(PaymentType::AttachedCycles),
+            SignerMethods::GenericCallerEcdsaPublicKey.fee(),
+        )
         .await?;
     generic::caller_ecdsa_public_key(arg).await
 }
@@ -129,9 +132,11 @@ async fn generic_sign_with_ecdsa(
     payment: Option<PaymentType>,
     arg: SignWithEcdsaArgument,
 ) -> Result<(SignWithEcdsaResponse,), GenericSignWithEcdsaError> {
-    let fee = 40_000_000_000; // Determined with the aid of scripts/check-pricing
     PAYMENT_GUARD
-        .deduct(payment.unwrap_or(PaymentType::AttachedCycles), fee)
+        .deduct(
+            payment.unwrap_or(PaymentType::AttachedCycles),
+            SignerMethods::GenericSignWithEcdsa.fee(),
+        )
         .await?;
     generic::sign_with_ecdsa(arg).await
 }
@@ -156,7 +161,7 @@ async fn eth_address(
     PAYMENT_GUARD
         .deduct(
             payment.unwrap_or(PaymentType::AttachedCycles),
-            1_000_000_000, // Determined with the aid of scripts/check-pricing
+            SignerMethods::EthAddress.fee(),
         )
         .await?;
     eth::eth_address(principal).await
@@ -175,7 +180,7 @@ async fn eth_address_of_caller(
     PAYMENT_GUARD
         .deduct(
             payment.unwrap_or(PaymentType::AttachedCycles),
-            1_000_000_000, // Determined with the aid of scripts/check-pricing
+            SignerMethods::EthAddressOfCaller.fee(),
         )
         .await?;
     eth::eth_address(principal).await
@@ -190,7 +195,7 @@ async fn eth_sign_transaction(
     PAYMENT_GUARD
         .deduct(
             payment.unwrap_or(PaymentType::AttachedCycles),
-            40_000_000_000, // Determined with the aid of scripts/check-pricing
+            SignerMethods::EthSignTransaction.fee(),
         )
         .await?;
     Ok(EthSignTransactionResponse {
@@ -207,7 +212,7 @@ async fn eth_personal_sign(
     PAYMENT_GUARD
         .deduct(
             payment.unwrap_or(PaymentType::AttachedCycles),
-            40_000_000_000, // Determined with the aid of scripts/check-pricing
+            SignerMethods::EthPersonalSign.fee(),
         )
         .await?;
     Ok(EthPersonalSignResponse {
@@ -224,7 +229,7 @@ async fn eth_sign_prehash(
     PAYMENT_GUARD
         .deduct(
             payment.unwrap_or(PaymentType::AttachedCycles),
-            40_000_000_000, // Determined with the aid of scripts/check-pricing
+            SignerMethods::EthSignPrehash.fee(),
         )
         .await?;
 
@@ -247,7 +252,7 @@ async fn btc_caller_address(
     PAYMENT_GUARD
         .deduct(
             payment.unwrap_or(PaymentType::AttachedCycles),
-            20_000_000, // Determined with the aid of scripts/check-pricing
+            SignerMethods::BtcCallerAddress.fee(),
         )
         .await?;
     match params.address_type {
@@ -272,7 +277,7 @@ async fn btc_caller_balance(
     PAYMENT_GUARD
         .deduct(
             payment.unwrap_or(PaymentType::AttachedCycles),
-            40_000_000, // Determined with the aid of scripts/check-pricing
+            SignerMethods::BtcCallerBalance.fee(),
         )
         .await?;
     match params.address_type {
@@ -302,7 +307,7 @@ async fn btc_caller_send(
     PAYMENT_GUARD
         .deduct(
             payment.unwrap_or(PaymentType::AttachedCycles),
-            130_000_000_000, // Determined with the aid of scripts/check-pricing
+            SignerMethods::BtcCallerSend.fee(),
         )
         .await?;
     match params.address_type {


### PR DESCRIPTION
# Motivation
Tests need to know how much each API method costs.

# Changes
- Move the signer fee definitions from lib.rs, where they are hard-wired, into a library where they are accessible for tests (and to developers using the signer).

# Tests
Existing CI should suffice.