### PR TITLE
chore(signer): Update ic-cdk

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -608,7 +608,7 @@ name = "example_backend"
 version = "0.2.7"
 dependencies = [
  "candid",
- "ic-cdk 0.16.0",
+ "ic-cdk 0.17.0",
 ]
 
 [[package]]
@@ -1028,6 +1028,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "ic-cdk"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2abdf9341da9f9f6b451a40609cb69645a05a8e9eb7784c16209f16f2c0f76f"
+dependencies = [
+ "candid",
+ "ic-cdk-macros 0.17.0",
+ "ic0 0.23.0",
+ "serde",
+ "serde_bytes",
+]
+
+[[package]]
 name = "ic-cdk-macros"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1070,6 +1083,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "ic-cdk-macros"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8df41980e95dead28735ab0f748c75477b0c5eab37a09a5641c78ec406a1db0"
+dependencies = [
+ "candid",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "serde_tokenstream 0.2.2",
+ "syn 2.0.85",
+]
+
+[[package]]
 name = "ic-certification"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1087,8 +1114,8 @@ version = "0.2.7"
 dependencies = [
  "candid",
  "ic-canister-sig-creation",
- "ic-cdk 0.16.0",
- "ic-cdk-macros 0.16.0",
+ "ic-cdk 0.17.0",
+ "ic-cdk-macros 0.17.0",
  "ic-metrics-encoder",
  "ic-papi-api",
  "serde",
@@ -2354,8 +2381,8 @@ dependencies = [
  "futures",
  "getrandom",
  "hex",
- "ic-cdk 0.16.0",
- "ic-cdk-macros 0.16.0",
+ "ic-cdk 0.17.0",
+ "ic-cdk-macros 0.17.0",
  "ic-chain-fusion-signer-api",
  "ic-papi-api",
  "ic-papi-guard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,6 @@ resolver = "2"
 [workspace.dependencies]
 ic-cdk = "0.17.0"
 ic-cdk-macros = "0.17.0"
-ic-cdk-timers = "0.9.0"
 ic-stable-structures = "0.6.5"
 ic-metrics-encoder = "1.1.1"
 ic-canister-sig-creation = "1.1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,8 +6,8 @@ members = [
 resolver = "2"
 
 [workspace.dependencies]
-ic-cdk = "0.16.0"
-ic-cdk-macros = "0.16.0"
+ic-cdk = "0.17.0"
+ic-cdk-macros = "0.17.0"
 ic-cdk-timers = "0.9.0"
 ic-stable-structures = "0.6.5"
 ic-metrics-encoder = "1.1.1"


### PR DESCRIPTION
# Motivation
To create Schnorr signatures, we need the next version of the `ic-cdk`.

# Changes
- Update the `ic-cdk` version.
- Remove the unused timers dependency from `Cargo.toml`

# Tests
Existing CI should suffice.