### PR TITLE
docs(signer): Expose API rustdocs

### DIFF
--- a/src/signer/canister/src/lib.rs
+++ b/src/signer/canister/src/lib.rs
@@ -121,7 +121,7 @@ pub async fn get_canister_status() -> std_canister_status::CanisterStatusResultV
 /// # Warnings
 /// - The user supplied derivation path is used as-is.  The caller is responsible for ensuring that unintended sub-keys are not requested.
 ///
-/// # Errors
+/// # Panics
 /// - If the caller is the anonymous user.
 #[update(guard = "caller_is_not_anonymous")]
 pub async fn generic_caller_ecdsa_public_key(
@@ -144,7 +144,7 @@ pub async fn generic_caller_ecdsa_public_key(
 /// # Warnings
 /// - The user supplied derivation path is used as-is.  The caller is responsible for ensuring that unintended sub-keys are not requested.
 ///
-/// # Errors
+/// # Panics
 /// - If the caller is the anonymous user.
 #[update(guard = "caller_is_not_anonymous")]
 pub async fn generic_sign_with_ecdsa(
@@ -168,7 +168,7 @@ pub async fn generic_sign_with_ecdsa(
 ///
 /// If no user is specified, the caller's address is returned.
 ///
-/// # Errors
+/// # Panics
 /// - If the caller is the anonymous user.
 #[update(guard = "caller_is_not_anonymous")]
 pub async fn eth_address(
@@ -191,7 +191,7 @@ pub async fn eth_address(
 
 /// Returns the Ethereum address of the caller.
 ///
-/// # Errors
+/// # Panics
 /// - If the caller is the anonymous user.
 #[update(guard = "caller_is_not_anonymous")]
 pub async fn eth_address_of_caller(
@@ -213,7 +213,7 @@ pub async fn eth_address_of_caller(
 
 /// Computes an Ethereum signature for an [EIP-1559](https://eips.ethereum.org/EIPS/eip-1559) transaction.
 ///
-/// # Errors
+/// # Panics
 /// - If the caller is the anonymous user.
 #[update(guard = "caller_is_not_anonymous")]
 pub async fn eth_sign_transaction(
@@ -233,7 +233,7 @@ pub async fn eth_sign_transaction(
 
 /// Computes an Ethereum signature for a hex-encoded message according to [EIP-191](https://eips.ethereum.org/EIPS/eip-191).
 ///
-/// # Errors
+/// # Panics
 /// - If the caller is the anonymous user.
 #[update(guard = "caller_is_not_anonymous")]
 pub async fn eth_personal_sign(
@@ -253,7 +253,7 @@ pub async fn eth_personal_sign(
 
 /// Computes an Ethereum signature for a precomputed hash.
 ///
-/// # Errors
+/// # Panics
 /// - If the caller is the anonymous user.
 #[update(guard = "caller_is_not_anonymous")]
 pub async fn eth_sign_prehash(
@@ -278,7 +278,7 @@ pub async fn eth_sign_prehash(
 
 /// Returns the Bitcoin address of the caller.
 ///
-/// # Errors
+/// # Panics
 /// - If the caller is the anonymous user.
 #[update(guard = "caller_is_not_anonymous")]
 #[allow(unused_variables)] // TODO: Remove this once the payment guard is used.
@@ -306,7 +306,7 @@ pub async fn btc_caller_address(
 
 /// Returns the Bitcoin balance of the caller's address.
 ///
-/// # Errors
+/// # Panics
 /// - If the caller is the anonymous user.
 #[update(guard = "caller_is_not_anonymous")]
 #[allow(unused_variables)] // TODO: Remove this once the payment guard is used.
@@ -339,7 +339,7 @@ pub async fn btc_caller_balance(
 
 /// Creates, signs and sends a BTC transaction from the caller's address.
 ///
-/// # Errors
+/// # Panics
 /// - If the caller is the anonymous user.
 #[update(guard = "caller_is_not_anonymous")]
 #[allow(unused_variables)] // TODO: Remove this once the payment guard is used.

--- a/src/signer/canister/src/lib.rs
+++ b/src/signer/canister/src/lib.rs
@@ -164,6 +164,9 @@ pub async fn generic_sign_with_ecdsa(
 /// Returns the Ethereum address of a specified user.
 ///
 /// If no user is specified, the caller's address is returned.
+///
+/// # Errors
+/// - If the caller is the anonymous user.
 #[update(guard = "caller_is_not_anonymous")]
 pub async fn eth_address(
     request: EthAddressRequest,
@@ -184,6 +187,9 @@ pub async fn eth_address(
 }
 
 /// Returns the Ethereum address of the caller.
+///
+/// # Errors
+/// - If the caller is the anonymous user.
 #[update(guard = "caller_is_not_anonymous")]
 pub async fn eth_address_of_caller(
     payment: Option<PaymentType>,
@@ -203,6 +209,9 @@ pub async fn eth_address_of_caller(
 }
 
 /// Computes an Ethereum signature for an [EIP-1559](https://eips.ethereum.org/EIPS/eip-1559) transaction.
+///
+/// # Errors
+/// - If the caller is the anonymous user.
 #[update(guard = "caller_is_not_anonymous")]
 pub async fn eth_sign_transaction(
     req: EthSignTransactionRequest,
@@ -220,6 +229,9 @@ pub async fn eth_sign_transaction(
 }
 
 /// Computes an Ethereum signature for a hex-encoded message according to [EIP-191](https://eips.ethereum.org/EIPS/eip-191).
+///
+/// # Errors
+/// - If the caller is the anonymous user.
 #[update(guard = "caller_is_not_anonymous")]
 pub async fn eth_personal_sign(
     request: EthPersonalSignRequest,
@@ -237,6 +249,9 @@ pub async fn eth_personal_sign(
 }
 
 /// Computes an Ethereum signature for a precomputed hash.
+///
+/// # Errors
+/// - If the caller is the anonymous user.
 #[update(guard = "caller_is_not_anonymous")]
 pub async fn eth_sign_prehash(
     req: EthSignPrehashRequest,
@@ -259,6 +274,9 @@ pub async fn eth_sign_prehash(
 // ///////////////////
 
 /// Returns the Bitcoin address of the caller.
+///
+/// # Errors
+/// - If the caller is the anonymous user.
 #[update(guard = "caller_is_not_anonymous")]
 #[allow(unused_variables)] // TODO: Remove this once the payment guard is used.
 pub async fn btc_caller_address(
@@ -284,6 +302,9 @@ pub async fn btc_caller_address(
 }
 
 /// Returns the Bitcoin balance of the caller's address.
+///
+/// # Errors
+/// - If the caller is the anonymous user.
 #[update(guard = "caller_is_not_anonymous")]
 #[allow(unused_variables)] // TODO: Remove this once the payment guard is used.
 pub async fn btc_caller_balance(
@@ -314,6 +335,9 @@ pub async fn btc_caller_balance(
 }
 
 /// Creates, signs and sends a BTC transaction from the caller's address.
+///
+/// # Errors
+/// - If the caller is the anonymous user.
 #[update(guard = "caller_is_not_anonymous")]
 #[allow(unused_variables)] // TODO: Remove this once the payment guard is used.
 pub async fn btc_caller_send(

--- a/src/signer/canister/src/lib.rs
+++ b/src/signer/canister/src/lib.rs
@@ -60,6 +60,9 @@ pub fn init(arg: Arg) {
 }
 
 /// Updates state after canister upgrade
+///
+/// # Panics
+/// - If there is an attempt to upgrade a canister without existing state.  This is most likely an attept to upgrade a new canister when an installation was intended.
 #[post_upgrade]
 pub fn post_upgrade(arg: Option<Arg>) {
     match arg {

--- a/src/signer/canister/src/lib.rs
+++ b/src/signer/canister/src/lib.rs
@@ -50,16 +50,18 @@ mod types;
 // // CANISTER MANAGEMENT //
 // /////////////////////////
 
+/// Initializes state on canister creation
 #[init]
-fn init(arg: Arg) {
+pub fn init(arg: Arg) {
     match arg {
         Arg::Init(arg) => set_config(arg),
         Arg::Upgrade => ic_cdk::trap("upgrade args in init"),
     }
 }
 
+/// Updates state after canister upgrade
 #[post_upgrade]
-fn post_upgrade(arg: Option<Arg>) {
+pub fn post_upgrade(arg: Option<Arg>) {
     match arg {
         Some(Arg::Init(arg)) => set_config(arg),
         _ => {
@@ -75,7 +77,7 @@ fn post_upgrade(arg: Option<Arg>) {
 /// Show the canister configuration.
 #[query(guard = "caller_is_not_anonymous")]
 #[must_use]
-fn config() -> Config {
+pub fn config() -> Config {
     read_config(std::clone::Clone::clone)
 }
 
@@ -101,7 +103,7 @@ pub fn http_request(request: HttpRequest) -> HttpResponse {
 
 /// API method to get cycle balance and burn rate.
 #[update]
-async fn get_canister_status() -> std_canister_status::CanisterStatusResultV2 {
+pub async fn get_canister_status() -> std_canister_status::CanisterStatusResultV2 {
     std_canister_status::get_canister_status_v2().await
 }
 
@@ -113,9 +115,13 @@ async fn get_canister_status() -> std_canister_status::CanisterStatusResultV2 {
 ///
 /// Note: This is an exact dual of the canister [`ecdsa_public_key`](https://internetcomputer.org/docs/current/references/ic-interface-spec/#ic-ecdsa_public_key) method.  The argument and response types are also the same.
 ///
-/// Warning: The user supplied derivation path is used as-is.  The caller is responsible for ensuring that unintended sub-keys are not requested.
+/// # Warnings
+/// - The user supplied derivation path is used as-is.  The caller is responsible for ensuring that unintended sub-keys are not requested.
+///
+/// # Errors
+/// - If the caller is the anonymous user.
 #[update(guard = "caller_is_not_anonymous")]
-async fn generic_caller_ecdsa_public_key(
+pub async fn generic_caller_ecdsa_public_key(
     arg: EcdsaPublicKeyArgument,
     payment: Option<PaymentType>,
 ) -> Result<(EcdsaPublicKeyResponse,), GenericCallerEcdsaPublicKeyError> {
@@ -132,9 +138,13 @@ async fn generic_caller_ecdsa_public_key(
 ///
 /// Note: This is an exact dual of the canister [`sign_with_ecdsa`](https://internetcomputer.org/docs/current/references/ic-interface-spec/#ic-sign_with_ecdsa) method.  The argument and response types are also the same.
 ///
-/// Warning: The user supplied derivation path is used as-is.  The caller is responsible for ensuring that unintended sub-keys are not requested.
+/// # Warnings
+/// - The user supplied derivation path is used as-is.  The caller is responsible for ensuring that unintended sub-keys are not requested.
+///
+/// # Errors
+/// - If the caller is the anonymous user.
 #[update(guard = "caller_is_not_anonymous")]
-async fn generic_sign_with_ecdsa(
+pub async fn generic_sign_with_ecdsa(
     payment: Option<PaymentType>,
     arg: SignWithEcdsaArgument,
 ) -> Result<(SignWithEcdsaResponse,), GenericSignWithEcdsaError> {
@@ -155,7 +165,7 @@ async fn generic_sign_with_ecdsa(
 ///
 /// If no user is specified, the caller's address is returned.
 #[update(guard = "caller_is_not_anonymous")]
-async fn eth_address(
+pub async fn eth_address(
     request: EthAddressRequest,
     payment: Option<PaymentType>,
 ) -> Result<EthAddressResponse, EthAddressError> {
@@ -175,7 +185,7 @@ async fn eth_address(
 
 /// Returns the Ethereum address of the caller.
 #[update(guard = "caller_is_not_anonymous")]
-async fn eth_address_of_caller(
+pub async fn eth_address_of_caller(
     payment: Option<PaymentType>,
 ) -> Result<EthAddressResponse, EthAddressError> {
     let principal = ic_cdk::caller();
@@ -194,7 +204,7 @@ async fn eth_address_of_caller(
 
 /// Computes an Ethereum signature for an [EIP-1559](https://eips.ethereum.org/EIPS/eip-1559) transaction.
 #[update(guard = "caller_is_not_anonymous")]
-async fn eth_sign_transaction(
+pub async fn eth_sign_transaction(
     req: EthSignTransactionRequest,
     payment: Option<PaymentType>,
 ) -> Result<EthSignTransactionResponse, EthSignTransactionError> {
@@ -211,7 +221,7 @@ async fn eth_sign_transaction(
 
 /// Computes an Ethereum signature for a hex-encoded message according to [EIP-191](https://eips.ethereum.org/EIPS/eip-191).
 #[update(guard = "caller_is_not_anonymous")]
-async fn eth_personal_sign(
+pub async fn eth_personal_sign(
     request: EthPersonalSignRequest,
     payment: Option<PaymentType>,
 ) -> Result<EthPersonalSignResponse, EthPersonalSignError> {
@@ -228,7 +238,7 @@ async fn eth_personal_sign(
 
 /// Computes an Ethereum signature for a precomputed hash.
 #[update(guard = "caller_is_not_anonymous")]
-async fn eth_sign_prehash(
+pub async fn eth_sign_prehash(
     req: EthSignPrehashRequest,
     payment: Option<PaymentType>,
 ) -> Result<EthSignPrehashResponse, EthSignPrehashError> {
@@ -251,7 +261,7 @@ async fn eth_sign_prehash(
 /// Returns the Bitcoin address of the caller.
 #[update(guard = "caller_is_not_anonymous")]
 #[allow(unused_variables)] // TODO: Remove this once the payment guard is used.
-async fn btc_caller_address(
+pub async fn btc_caller_address(
     params: GetAddressRequest,
     payment: Option<PaymentType>, // Note: Do NOT use underscore, please, so that the underscore doesn't show up in the generated candid.
 ) -> Result<GetAddressResponse, GetAddressError> {
@@ -276,7 +286,7 @@ async fn btc_caller_address(
 /// Returns the Bitcoin balance of the caller's address.
 #[update(guard = "caller_is_not_anonymous")]
 #[allow(unused_variables)] // TODO: Remove this once the payment guard is used.
-async fn btc_caller_balance(
+pub async fn btc_caller_balance(
     params: GetBalanceRequest,
     payment: Option<PaymentType>, // Note: Do NOT use underscore, please, so that the underscore doesn't show up in the generated candid.
 ) -> Result<GetBalanceResponse, GetBalanceError> {
@@ -306,7 +316,7 @@ async fn btc_caller_balance(
 /// Creates, signs and sends a BTC transaction from the caller's address.
 #[update(guard = "caller_is_not_anonymous")]
 #[allow(unused_variables)] // TODO: Remove this once the payment guard is used.
-async fn btc_caller_send(
+pub async fn btc_caller_send(
     params: SendBtcRequest,
     payment: Option<PaymentType>,
 ) -> Result<SendBtcResponse, SendBtcError> {


### PR DESCRIPTION
# Motivation
The signer canister API documentation is inadequate.

# Changes
- Make the API functions public.  In this way, the API rustdoc is generated by default.
- Add the most important missing documentation: Mostly that most methods will fail if called by the anonymous user.

# Tests
Existing CI should suffice.