### PR TITLE
chore(signer): Remove unneeded clippy allows

### DIFF
--- a/src/signer/canister/src/lib.rs
+++ b/src/signer/canister/src/lib.rs
@@ -281,7 +281,6 @@ pub async fn eth_sign_prehash(
 /// # Panics
 /// - If the caller is the anonymous user.
 #[update(guard = "caller_is_not_anonymous")]
-#[allow(unused_variables)] // TODO: Remove this once the payment guard is used.
 pub async fn btc_caller_address(
     params: GetAddressRequest,
     payment: Option<PaymentType>, // Note: Do NOT use underscore, please, so that the underscore doesn't show up in the generated candid.
@@ -309,7 +308,6 @@ pub async fn btc_caller_address(
 /// # Panics
 /// - If the caller is the anonymous user.
 #[update(guard = "caller_is_not_anonymous")]
-#[allow(unused_variables)] // TODO: Remove this once the payment guard is used.
 pub async fn btc_caller_balance(
     params: GetBalanceRequest,
     payment: Option<PaymentType>, // Note: Do NOT use underscore, please, so that the underscore doesn't show up in the generated candid.
@@ -342,7 +340,6 @@ pub async fn btc_caller_balance(
 /// # Panics
 /// - If the caller is the anonymous user.
 #[update(guard = "caller_is_not_anonymous")]
-#[allow(unused_variables)] // TODO: Remove this once the payment guard is used.
 pub async fn btc_caller_send(
     params: SendBtcRequest,
     payment: Option<PaymentType>,


### PR DESCRIPTION
# Motivation
Now that all APIs charge for use, some clippy lints can be re-enabled.

# Changes
- Remove clippy lints.

# Tests
Existing CI should suffice.