### PR TITLE
chore(rust): Tighten formatting rules

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,1 +1,6 @@
+unstable_features = true
+wrap_comments = true
+comment_width = 120
 imports_granularity = "Crate"
+imports_layout = "Vertical"
+group_imports = "StdExternalCrate"

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,6 +1,4 @@
-unstable_features = true
 wrap_comments = true
 comment_width = 120
 imports_granularity = "Crate"
-imports_layout = "Vertical"
 group_imports = "StdExternalCrate"

--- a/src/signer/api/src/impls.rs
+++ b/src/signer/api/src/impls.rs
@@ -1,9 +1,10 @@
+use ic_canister_sig_creation::{extract_raw_root_pk_from_der, IC_ROOT_PK_DER};
+use ic_papi_api::PaymentError;
+
 use crate::types::{
     bitcoin::{GetAddressError, GetBalanceError, SendBtcError},
     Config, InitArg,
 };
-use ic_canister_sig_creation::{extract_raw_root_pk_from_der, IC_ROOT_PK_DER};
-use ic_papi_api::PaymentError;
 
 impl From<InitArg> for Config {
     /// Creates a new `Config` from the provided `InitArg`.

--- a/src/signer/api/src/metrics.rs
+++ b/src/signer/api/src/metrics.rs
@@ -1,12 +1,14 @@
 //! Canister health metrics.
 
-use crate::http::HttpResponse;
 #[cfg(target_arch = "wasm32")]
 use core::arch::wasm32::memory_size as wasm_memory_size;
+
 #[cfg(target_arch = "wasm32")]
 use ic_cdk::api::stable::stable_size;
 use ic_metrics_encoder::MetricsEncoder;
 use serde_bytes::ByteBuf;
+
+use crate::http::HttpResponse;
 /// The Wasm page size as defined in [the Wasm Spec](https://webassembly.github.io/spec/core/exec/runtime.html#memory-instances).
 #[cfg(target_arch = "wasm32")]
 const WASM_PAGE_SIZE: u64 = 65536;

--- a/src/signer/api/src/std_canister_status.rs
+++ b/src/signer/api/src/std_canister_status.rs
@@ -1,10 +1,12 @@
 //! Support for the standard `get_canister_status` method returning a `CanisterStatusResultV2`.
 //!
-//! Note: This API is used my many canisters but the code is not packaged up in a portable way and implementations typically use old APIs to get the data.
+//! Note: This API is used my many canisters but the code is not packaged up in a portable way and
+//! implementations typically use old APIs to get the data.
 //!
 //! The `ic_cdk` has a method called [`canister_status`](https://docs.rs/ic-cdk/0.10.0/ic_cdk/api/management_canister/main/fn.canister_status.html)
-//! with all the same data.  Consumers such as the cycle management canister should consider supporting that.  In the meantime we convert the type used in the
-//! current `ic_cdk` into the currently requested `CanisterStatusResultV2`.
+//! with all the same data.  Consumers such as the cycle management canister should consider
+//! supporting that.  In the meantime we convert the type used in the current `ic_cdk` into the
+//! currently requested `CanisterStatusResultV2`.
 
 use candid::{CandidType, Deserialize, Nat, Principal};
 use ic_cdk::api::management_canister::main::{
@@ -79,7 +81,8 @@ impl TryFrom<DefiniteCanisterSettings> for DefiniteCanisterSettingsArgs {
             compute_allocation,
             memory_allocation,
             freezing_threshold,
-            // TODO: should API method get_canister_status be extended with additional information such as reserved_cycles_limit, log_visibility, or wasm_memory_limit?
+            // TODO: should API method get_canister_status be extended with additional information
+            // such as reserved_cycles_limit, log_visibility, or wasm_memory_limit?
             ..
         } = value;
         Ok(Self {
@@ -100,7 +103,8 @@ impl TryFrom<DefiniteCanisterSettings> for DefiniteCanisterSettingsArgs {
 ///
 /// # Panics
 /// - If the call to the management canister fails.
-/// - If the response cannot be converted to `CanisterStatusResultV2`.  For example, it looks as if it will panic if the canister has no controllers.
+/// - If the response cannot be converted to `CanisterStatusResultV2`.  For example, it looks as if
+///   it will panic if the canister has no controllers.
 pub async fn get_canister_status_v2() -> CanisterStatusResultV2 {
     let canister_id = ic_cdk::api::id(); // Own canister ID.
     canister_status(CanisterIdRecord { canister_id })

--- a/src/signer/api/src/types.rs
+++ b/src/signer/api/src/types.rs
@@ -1,5 +1,6 @@
-use candid::{CandidType, Deserialize, Principal};
 use std::fmt::Debug;
+
+use candid::{CandidType, Deserialize, Principal};
 
 pub mod eth;
 pub mod generic;

--- a/src/signer/api/src/types/eth.rs
+++ b/src/signer/api/src/types/eth.rs
@@ -1,6 +1,7 @@
-use super::transaction;
 use candid::{CandidType, Deserialize, Nat, Principal};
 use ic_cdk::api::call::RejectionCode;
+
+use super::transaction;
 
 #[derive(CandidType, Deserialize, Debug, Clone)]
 pub struct EthAddressRequest {
@@ -16,7 +17,8 @@ pub struct EthAddressResponse {
 pub enum EthAddressError {
     /// Payment failed.
     PaymentError(ic_papi_api::PaymentError),
-    /// An `ic_cdk::call::CallResult` error received when making the canister thereshold signature API call.
+    /// An `ic_cdk::call::CallResult` error received when making the canister thereshold signature
+    /// API call.
     SigningError(RejectionCode, String),
 }
 impl From<ic_papi_api::PaymentError> for EthAddressError {
@@ -65,7 +67,8 @@ pub struct EthSignTransactionResponse {
 pub enum EthSignTransactionError {
     /// Payment failed.
     PaymentError(ic_papi_api::PaymentError),
-    /// An `ic_cdk::call::CallResult` error received when making the canister thereshold signature API call.
+    /// An `ic_cdk::call::CallResult` error received when making the canister thereshold signature
+    /// API call.
     SigningError(RejectionCode, String),
 }
 impl From<ic_papi_api::PaymentError> for EthSignTransactionError {
@@ -91,7 +94,8 @@ pub struct EthPersonalSignResponse {
 pub enum EthPersonalSignError {
     /// Payment failed.
     PaymentError(ic_papi_api::PaymentError),
-    /// An `ic_cdk::call::CallResult` error received when making the canister thereshold signature API call.
+    /// An `ic_cdk::call::CallResult` error received when making the canister thereshold signature
+    /// API call.
     SigningError(RejectionCode, String),
 }
 impl From<ic_papi_api::PaymentError> for EthPersonalSignError {
@@ -117,7 +121,8 @@ pub struct EthSignPrehashResponse {
 pub enum EthSignPrehashError {
     /// Payment failed.
     PaymentError(ic_papi_api::PaymentError),
-    /// An `ic_cdk::call::CallResult` error received when making the canister thereshold signature API call.
+    /// An `ic_cdk::call::CallResult` error received when making the canister thereshold signature
+    /// API call.
     SigningError(RejectionCode, String),
 }
 impl From<ic_papi_api::PaymentError> for EthSignPrehashError {

--- a/src/signer/api/src/types/generic.rs
+++ b/src/signer/api/src/types/generic.rs
@@ -5,7 +5,8 @@ use ic_cdk::api::call::RejectionCode;
 pub enum GenericSigningError {
     /// Payment failed.
     PaymentError(ic_papi_api::PaymentError),
-    /// An `ic_cdk::call::CallResult` error received when making the canister thereshold signature API call.
+    /// An `ic_cdk::call::CallResult` error received when making the canister thereshold signature
+    /// API call.
     SigningError(RejectionCode, String),
 }
 
@@ -19,7 +20,8 @@ impl From<ic_papi_api::PaymentError> for GenericSigningError {
 pub enum GenericCallerEcdsaPublicKeyError {
     /// Payment failed.
     PaymentError(ic_papi_api::PaymentError),
-    /// An `ic_cdk::call::CallResult` error received when making the canister thereshold signature API call.
+    /// An `ic_cdk::call::CallResult` error received when making the canister thereshold signature
+    /// API call.
     SigningError(RejectionCode, String),
 }
 impl From<ic_papi_api::PaymentError> for GenericCallerEcdsaPublicKeyError {
@@ -37,7 +39,8 @@ impl From<(RejectionCode, String)> for GenericCallerEcdsaPublicKeyError {
 pub enum GenericSignWithEcdsaError {
     /// Payment failed.
     PaymentError(ic_papi_api::PaymentError),
-    /// An `ic_cdk::call::CallResult` error received when making the canister thereshold signature API call.
+    /// An `ic_cdk::call::CallResult` error received when making the canister thereshold signature
+    /// API call.
     SigningError(RejectionCode, String),
 }
 impl From<ic_papi_api::PaymentError> for GenericSignWithEcdsaError {

--- a/src/signer/canister/src/derivation_path.rs
+++ b/src/signer/canister/src/derivation_path.rs
@@ -17,14 +17,16 @@ pub enum Schema {
 }
 
 impl From<Schema> for Vec<u8> {
-    /// The first part of a derivation path is the schema.  Typically a single byte but may be any number of bytes.
+    /// The first part of a derivation path is the schema.  Typically a single byte but may be any
+    /// number of bytes.
     fn from(s: Schema) -> Vec<u8> {
         vec![s as u8]
     }
 }
 
 impl Schema {
-    /// The caller may specify any derivation path, as long as it starts with schema and caller principal.
+    /// The caller may specify any derivation path, as long as it starts with schema and caller
+    /// principal.
     pub fn derivation_path(self, principal: &Principal) -> Vec<Vec<u8>> {
         vec![self.into(), principal.as_slice().to_vec()]
     }

--- a/src/signer/canister/src/impls.rs
+++ b/src/signer/canister/src/impls.rs
@@ -1,8 +1,10 @@
-use crate::types::{Candid, StoredPrincipal};
-use candid::{CandidType, Deserialize, Principal};
 use core::ops::Deref;
-use ic_stable_structures::storable::{Blob, Bound, Storable};
 use std::borrow::Cow;
+
+use candid::{CandidType, Deserialize, Principal};
+use ic_stable_structures::storable::{Blob, Bound, Storable};
+
+use crate::types::{Candid, StoredPrincipal};
 
 impl<T> Storable for Candid<T>
 where

--- a/src/signer/canister/src/lib.rs
+++ b/src/signer/canister/src/lib.rs
@@ -1,4 +1,3 @@
-use crate::guards::caller_is_not_anonymous;
 use candid::Principal;
 use ic_cdk::api::management_canister::ecdsa::{
     EcdsaPublicKeyArgument, EcdsaPublicKeyResponse, SignWithEcdsaArgument, SignWithEcdsaResponse,
@@ -38,6 +37,8 @@ use sign::{
 };
 use state::{read_config, read_state, set_config, PAYMENT_GUARD};
 
+use crate::guards::caller_is_not_anonymous;
+
 mod convert;
 mod derivation_path;
 mod guards;
@@ -62,7 +63,8 @@ pub fn init(arg: Arg) {
 /// Updates state after canister upgrade
 ///
 /// # Panics
-/// - If there is an attempt to upgrade a canister without existing state.  This is most likely an attept to upgrade a new canister when an installation was intended.
+/// - If there is an attempt to upgrade a canister without existing state.  This is most likely an
+///   attept to upgrade a new canister when an installation was intended.
 #[post_upgrade]
 pub fn post_upgrade(arg: Option<Arg>) {
     match arg {
@@ -119,7 +121,8 @@ pub async fn get_canister_status() -> std_canister_status::CanisterStatusResultV
 /// Note: This is an exact dual of the canister [`ecdsa_public_key`](https://internetcomputer.org/docs/current/references/ic-interface-spec/#ic-ecdsa_public_key) method.  The argument and response types are also the same.
 ///
 /// # Warnings
-/// - The user supplied derivation path is used as-is.  The caller is responsible for ensuring that unintended sub-keys are not requested.
+/// - The user supplied derivation path is used as-is.  The caller is responsible for ensuring that
+///   unintended sub-keys are not requested.
 ///
 /// # Panics
 /// - If the caller is the anonymous user.
@@ -142,7 +145,8 @@ pub async fn generic_caller_ecdsa_public_key(
 /// Note: This is an exact dual of the canister [`sign_with_ecdsa`](https://internetcomputer.org/docs/current/references/ic-interface-spec/#ic-sign_with_ecdsa) method.  The argument and response types are also the same.
 ///
 /// # Warnings
-/// - The user supplied derivation path is used as-is.  The caller is responsible for ensuring that unintended sub-keys are not requested.
+/// - The user supplied derivation path is used as-is.  The caller is responsible for ensuring that
+///   unintended sub-keys are not requested.
 ///
 /// # Panics
 /// - If the caller is the anonymous user.
@@ -283,7 +287,8 @@ pub async fn eth_sign_prehash(
 #[update(guard = "caller_is_not_anonymous")]
 pub async fn btc_caller_address(
     params: GetAddressRequest,
-    payment: Option<PaymentType>, // Note: Do NOT use underscore, please, so that the underscore doesn't show up in the generated candid.
+    payment: Option<PaymentType>, /* Note: Do NOT use underscore, please, so that the underscore
+                                   * doesn't show up in the generated candid. */
 ) -> Result<GetAddressResponse, GetAddressError> {
     PAYMENT_GUARD
         .deduct(
@@ -310,7 +315,8 @@ pub async fn btc_caller_address(
 #[update(guard = "caller_is_not_anonymous")]
 pub async fn btc_caller_balance(
     params: GetBalanceRequest,
-    payment: Option<PaymentType>, // Note: Do NOT use underscore, please, so that the underscore doesn't show up in the generated candid.
+    payment: Option<PaymentType>, /* Note: Do NOT use underscore, please, so that the underscore
+                                   * doesn't show up in the generated candid. */
 ) -> Result<GetBalanceResponse, GetBalanceError> {
     PAYMENT_GUARD
         .deduct(

--- a/src/signer/canister/src/sign/bitcoin/bitcoin_utils.rs
+++ b/src/signer/canister/src/sign/bitcoin/bitcoin_utils.rs
@@ -1,11 +1,12 @@
 //! Code for signing Bitcoin transactions.
-use crate::{derivation_path::Schema, state::read_config};
 use bitcoin::{Address, CompressedPublicKey, Network};
 use candid::Principal;
 use ic_cdk::api::management_canister::{
     bitcoin::BitcoinNetwork,
     ecdsa::{ecdsa_public_key, EcdsaCurve, EcdsaKeyId, EcdsaPublicKeyArgument},
 };
+
+use crate::{derivation_path::Schema, state::read_config};
 
 /// Computes the public key of the specified principal.
 async fn ecdsa_pubkey_of(principal: &Principal) -> Result<Vec<u8>, String> {

--- a/src/signer/canister/src/sign/bitcoin/fee_utils.rs
+++ b/src/signer/canister/src/sign/bitcoin/fee_utils.rs
@@ -1,9 +1,11 @@
-use super::bitcoin_api;
 use ic_cdk::api::management_canister::bitcoin::{BitcoinNetwork, Utxo};
+
+use super::bitcoin_api;
 
 /// Functions stolen from [ckBTC Minter](https://github.com/dfinity/ic/blob/285a5db07da50a4e350ec43bf3b488cc6fe36102/rs/bitcoin/ckbtc/minter/src/lib.rs#L1258)
 
-/// Computes an estimate for the size of transaction (in vbytes) with the given number of inputs and outputs.
+/// Computes an estimate for the size of transaction (in vbytes) with the given number of inputs and
+/// outputs.
 fn tx_vsize_estimate(input_count: u64, output_count: u64) -> u64 {
     // See
     // [Bitcoin wiki](https://github.com/bitcoin/bips/blob/master/bip-0141.mediawiki)

--- a/src/signer/canister/src/sign/bitcoin/tx_utils.rs
+++ b/src/signer/canister/src/sign/bitcoin/tx_utils.rs
@@ -1,10 +1,5 @@
-use crate::{
-    derivation_path::Schema,
-    sign::{
-        bitcoin::bitcoin_utils::transform_network,
-        ecdsa_api::{ecdsa_pubkey_of, get_ecdsa_signature},
-    },
-};
+use std::str::FromStr;
+
 use bitcoin::{
     absolute::LockTime, consensus::serialize, hashes::Hash, script::PushBytesBuf,
     sighash::SighashCache, transaction::Version, Address, AddressType, Amount, EcdsaSighashType,
@@ -13,7 +8,14 @@ use bitcoin::{
 use candid::Principal;
 use ic_cdk::api::management_canister::bitcoin::{BitcoinNetwork, Outpoint as IcCdkOutPoint, Utxo};
 use ic_chain_fusion_signer_api::types::bitcoin::{BtcTxOutput, BuildP2wpkhTxError};
-use std::str::FromStr;
+
+use crate::{
+    derivation_path::Schema,
+    sign::{
+        bitcoin::bitcoin_utils::transform_network,
+        ecdsa_api::{ecdsa_pubkey_of, get_ecdsa_signature},
+    },
+};
 
 const ECDSA_SIG_HASH_TYPE: EcdsaSighashType = EcdsaSighashType::All;
 // Assume that any amount below this threshold is dust.
@@ -456,7 +458,9 @@ mod tests {
             build_p2wpkh_transaction(source_address, BitcoinNetwork::Mainnet, &[], 10, &vec![]);
 
         match result {
-            Err(BuildP2wpkhTxError::NotP2WPKHSourceAddress) => {} // Success if this error is returned
+            // Expect this error:
+            Err(BuildP2wpkhTxError::NotP2WPKHSourceAddress) => {}
+            // Anything else is wrong:
             _ => panic!("Expected NotP2WPKHSourceAddress error"),
         }
     }

--- a/src/signer/canister/src/sign/eth.rs
+++ b/src/signer/canister/src/sign/eth.rs
@@ -1,8 +1,5 @@
-use crate::{
-    convert::{decode_hex, nat_to_u256, nat_to_u64},
-    derivation_path::Schema,
-    state::read_config,
-};
+use std::str::FromStr;
+
 use candid::Principal;
 use ethers_core::{
     abi::ethereum_types::{Address, U256},
@@ -13,13 +10,17 @@ use ic_cdk::api::management_canister::ecdsa::{
     ecdsa_public_key, sign_with_ecdsa, EcdsaCurve, EcdsaKeyId, EcdsaPublicKeyArgument,
     SignWithEcdsaArgument,
 };
+pub use ic_chain_fusion_signer_api::types::eth::{
+    EthAddressError, EthAddressRequest, EthAddressResponse,
+};
 use ic_chain_fusion_signer_api::types::{eth::EthSignTransactionError, transaction::SignRequest};
 use k256::PublicKey;
 use pretty_assertions::assert_eq;
-use std::str::FromStr;
 
-pub use ic_chain_fusion_signer_api::types::eth::{
-    EthAddressError, EthAddressRequest, EthAddressResponse,
+use crate::{
+    convert::{decode_hex, nat_to_u256, nat_to_u64},
+    derivation_path::Schema,
+    state::read_config,
 };
 
 /// Converts the public key bytes to an Ethereum address with a checksum.

--- a/src/signer/canister/src/sign/generic.rs
+++ b/src/signer/canister/src/sign/generic.rs
@@ -1,5 +1,4 @@
 //! A generic signing API equivalent to that provided by the canister API.
-use crate::derivation_path::Schema;
 use ic_cdk::api::management_canister::{
     ecdsa as canister_ecdsa,
     ecdsa::{
@@ -11,9 +10,12 @@ pub use ic_chain_fusion_signer_api::types::generic::{
     GenericCallerEcdsaPublicKeyError, GenericSignWithEcdsaError,
 };
 
+use crate::derivation_path::Schema;
+
 /// A generic ECDSA public key for the user.
 ///
-/// Warning: The user supplied derivation path is used as-is.  The caller is responsible for ensuring that unintended sub-keys are not requested.
+/// Warning: The user supplied derivation path is used as-is.  The caller is responsible for
+/// ensuring that unintended sub-keys are not requested.
 pub async fn caller_ecdsa_public_key(
     mut arg: EcdsaPublicKeyArgument,
 ) -> Result<(EcdsaPublicKeyResponse,), GenericCallerEcdsaPublicKeyError> {
@@ -24,7 +26,8 @@ pub async fn caller_ecdsa_public_key(
 
 /// Signs a message with a generic ECDSA key for the user.
 ///
-/// Warning: The user supplied derivation path is used as-is.  The caller is responsible for ensuring that unintended sub-keys are not requested.
+/// Warning: The user supplied derivation path is used as-is.  The caller is responsible for
+/// ensuring that unintended sub-keys are not requested.
 pub async fn sign_with_ecdsa(
     mut arg: SignWithEcdsaArgument,
 ) -> Result<(SignWithEcdsaResponse,), GenericSignWithEcdsaError> {

--- a/src/signer/canister/src/state.rs
+++ b/src/signer/canister/src/state.rs
@@ -1,4 +1,5 @@
-use crate::types::{Candid, ConfigCell};
+use std::cell::RefCell;
+
 use candid::Principal;
 use ic_chain_fusion_signer_api::types::{Config, InitArg};
 use ic_papi_guard::guards::any::{PaymentGuard, VendorPaymentConfig};
@@ -7,7 +8,8 @@ use ic_stable_structures::{
     DefaultMemoryImpl,
 };
 use lazy_static::lazy_static;
-use std::cell::RefCell;
+
+use crate::types::{Candid, ConfigCell};
 
 const CONFIG_MEMORY_ID: MemoryId = MemoryId::new(0);
 

--- a/src/signer/canister/tests/it/bitcoin.rs
+++ b/src/signer/canister/tests/it/bitcoin.rs
@@ -1,3 +1,6 @@
+use candid::Principal;
+use ic_chain_fusion_signer_api::methods::SignerMethods;
+
 use crate::{
     canister::{
         cycles_ledger::{self, ApproveArgs},
@@ -14,8 +17,6 @@ use crate::{
         test_environment::{TestSetup, LEDGER_FEE},
     },
 };
-use candid::Principal;
-use ic_chain_fusion_signer_api::methods::SignerMethods;
 
 mod caller_balance {
     use super::*;

--- a/src/signer/canister/tests/it/eth.rs
+++ b/src/signer/canister/tests/it/eth.rs
@@ -1,4 +1,8 @@
 //! Tests for ethereum methods on the signer canister.
+use candid::{Nat, Principal};
+use ic_chain_fusion_signer_api::methods::SignerMethods;
+use lazy_static::lazy_static;
+
 use crate::{
     canister::{
         cycles_ledger::{self, ApproveArgs},
@@ -14,9 +18,6 @@ use crate::{
         test_environment::{TestSetup, LEDGER_FEE},
     },
 };
-use candid::{Nat, Principal};
-use ic_chain_fusion_signer_api::methods::SignerMethods;
-use lazy_static::lazy_static;
 
 lazy_static! {
     static ref GOOD_SIGN_TRANSACTION_REQUEST: EthSignTransactionRequest =
@@ -37,9 +38,8 @@ lazy_static! {
 
 /// Tests for `eth_sign_transaction()`
 mod sign_transaction {
-    use crate::canister::signer::EthAddressError;
-
     use super::*;
+    use crate::canister::signer::EthAddressError;
 
     /// A standard sign_transaction call, including payment.
     fn paid_sign_transaction(
@@ -154,7 +154,8 @@ mod personal_sign {
     fn cannot_personal_sign_if_message_is_not_hex_string() {
         let test_env = TestSetup::default();
         let request = EthPersonalSignRequest {
-            message: "test message".to_string(), // Note: This should be a hex string.  Let' stest what happens when it's not.
+            message: "test message".to_string(), /* Note: This should be a hex string.  Let'
+                                                  * stest what happens when it's not. */
         };
         let response = paid_personal_sign(&test_env, test_env.user, &request);
         assert!(response.is_err());

--- a/src/signer/canister/tests/it/utils/pic_canister.rs
+++ b/src/signer/canister/tests/it/utils/pic_canister.rs
@@ -1,19 +1,21 @@
 //! Common methods for interacting with a canister using `PocketIc`.
-use candid::{
-    decode_one, encode_args, encode_one, utils::ArgumentEncoder, CandidType, Deserialize, Principal,
-};
-use pocket_ic::{PocketIc, WasmResult};
 use std::{
     fs,
     path::{Path, PathBuf},
     sync::Arc,
 };
 
+use candid::{
+    decode_one, encode_args, encode_one, utils::ArgumentEncoder, CandidType, Deserialize, Principal,
+};
+use pocket_ic::{PocketIc, WasmResult};
+
 /// Common methods for interacting with a canister using `PocketIc`.
 pub trait PicCanisterTrait {
     /// A shared PocketIc instance.
     ///
-    /// Note: `PocketIc` uses interior mutability for query and update calls.  No external mut annotation or locks appear to be necessary.
+    /// Note: `PocketIc` uses interior mutability for query and update calls.  No external mut
+    /// annotation or locks appear to be necessary.
     fn pic(&self) -> Arc<PocketIc>;
 
     /// The ID of this canister.
@@ -97,7 +99,8 @@ pub fn cargo_wasm_path(name: &str) -> String {
 }
 /// The path to the wasm after `dfx deploy`.  Expects the Wasm to be gzipped.
 ///
-/// If not already gzipped, please add this to the canister declaration in `dfx.json`: `"gzip": true`
+/// If not already gzipped, please add this to the canister declaration in `dfx.json`: `"gzip":
+/// true`
 #[allow(dead_code)]
 pub fn dfx_wasm_path(name: &str) -> String {
     workspace_dir()

--- a/src/signer/canister/tests/it/utils/test_environment.rs
+++ b/src/signer/canister/tests/it/utils/test_environment.rs
@@ -1,3 +1,9 @@
+use std::sync::Arc;
+
+use candid::{encode_one, Nat, Principal};
+use ic_papi_api::cycles::cycles_ledger_canister_id;
+use pocket_ic::{PocketIc, PocketIcBuilder};
+
 use super::mock::CALLER;
 use crate::{
     canister::{
@@ -10,10 +16,6 @@ use crate::{
     },
     utils::pic_canister::{cargo_wasm_path, dfx_wasm_path, PicCanisterBuilder, PicCanisterTrait},
 };
-use candid::{encode_one, Nat, Principal};
-use ic_papi_api::cycles::cycles_ledger_canister_id;
-use pocket_ic::{PocketIc, PocketIcBuilder};
-use std::sync::Arc;
 
 pub const BITCOIN_CANISTER_ID: &str = "g4xu7-jiaaa-aaaan-aaaaq-cai";
 pub const LEDGER_FEE: u128 = 100_000_000; // The documented fee: https://internetcomputer.org/docs/current/developer-docs/defi/cycles/cycles-ledger#fees
@@ -34,7 +36,8 @@ pub struct TestSetup {
     pub user2: Principal,
     /// A crowd
     pub users: [Principal; 5],
-    /// Unauthorized user, used in tests to ensure that random third parties cannot use resources they are not entitled to.
+    /// Unauthorized user, used in tests to ensure that random third parties cannot use resources
+    /// they are not entitled to.
     pub unauthorized_user: Principal,
     /// A canister used to deposit cycles into the ledger.
     pub cycles_depositor: CyclesDepositorPic,
@@ -56,7 +59,8 @@ impl Default for TestSetup {
             .create_canister_with_id(None, None, cycles_ledger_canister_id())
             .unwrap();
 
-        // Would like to create this with the cycles ledger canister ID but currently this yields an error.
+        // Would like to create this with the cycles ledger canister ID but currently this yields an
+        // error.
         let ledger = CyclesLedgerPic::from(
             PicCanisterBuilder::default()
                 .with_canister(cycles_ledger_canister_id)


### PR DESCRIPTION
# Motivation
Niggling formatting differences causing spurious diffs.

# Changes
- Specify Rust formatting more precisely.

# Tests
Existing CI checks that formatting is as expected.