### PR TITLE
feat(release): Wait for release

### DIFF
--- a/scripts/release
+++ b/scripts/release
@@ -11,3 +11,6 @@ version="$(cargo metadata --format-version 1 | jq -r '.packages[] | select(.name
 tag="v$version"
 git tag "$tag"
 git push origin "refs/tags/$tag"
+echo "Waiting for GitHub release action..."
+sleep 5
+gh run watch "$(gh run list --workflow Release --branch "$tag" --json databaseId -q '.[0].databaseId')"


### PR DESCRIPTION
# Motivation
After running the release action, it is necessary to wait for the release github action before proceeding with the next step.

This can be automated. As I waited with the CLI we might as well reuse the cli.

# Changes
- Wait for the GitHub release action.

# Tests
I used this in the last release.