### PR TITLE
fix(docs): Fix no-cache documentation

### DIFF
--- a/scripts/docker-build
+++ b/scripts/docker-build
@@ -32,7 +32,7 @@ print_docker_help() {
   cat <<-"EOF"
 	Note: If the docker build fails, it may help to build from a clean cache:
 
-	  ./scripts/docker-build -- --no-cache
+	  ./scripts/docker-build --no-cache
 
 	EOF
 }


### PR DESCRIPTION
# Motivation
The help message for a no-cache docker build is inaccurate.  The help message is accurate if there is an argument parser that stops at the `--` but that is not the case in this build script.

# Changes
- Provide the correct flag for running with no-cache.

# Tests
- I have run locally with no-cache.
- It probably doesn't make sense to have a no-cache test in CI as this would significantly slow down every PR.