### PR TITLE
feat(devops): Build binary args

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -97,7 +97,7 @@ jobs:
       - name: Install dfx
         uses: dfinity/setup-dfx@main
       - name: Install build tools
-        run: scripts/setup cargo-binstall candid-extractor ic-wasm
+        run: scripts/setup cargo-binstall candid-extractor ic-wasm didc
       - name: Start dfx
         run: dfx start --clean --background
       - name: Deploy all canisters

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,7 +36,7 @@ SHELL ["bash", "-c"]
 # Install dfx
 # Note: dfx is installed in `$HOME/.local/share/dfx/bin` but we can't reference `$HOME` here so we hardcode `/root`.
 COPY --from=tool_versions /config/*_version config/
-ENV PATH="/root/.local/share/dfx/bin:${PATH}"
+ENV PATH="/root/.local/share/dfx/bin:/root/.local/bin:${PATH}"
 RUN DFXVM_INIT_YES=true DFX_VERSION="$(cat config/dfx_version)" sh -c "$(curl -fsSL https://sdk.dfinity.org/install.sh)" && dfx --version
 # Install Rust
 COPY ./rust-toolchain.toml .
@@ -45,7 +45,11 @@ ENV RUSTUP_HOME=/opt/rustup \
     PATH=/cargo/bin:$PATH
 COPY dev-tools.json dev-tools.json
 COPY scripts/setup scripts/setup-cargo-binstall scripts/setup-rust scripts/
-RUN scripts/setup rust cargo-binstall candid-extractor ic-wasm
+RUN scripts/setup rust
+RUN scripts/setup cargo-binstall
+RUN scripts/setup candid-extractor
+RUN scripts/setup ic-wasm
+RUN scripts/setup didc
 # Optional: Pre-build dependencies
 COPY Cargo.lock .
 COPY Cargo.toml .

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt update && apt install -y \
     clang \
     cmake \
     jq \
+    xxd \
     && rm -rf /var/lib/apt/lists/*
 
 

--- a/scripts/build.signer.args.sh
+++ b/scripts/build.signer.args.sh
@@ -62,9 +62,14 @@ cat <<EOF >"$ARG_FILE"
   })
 EOF
 
+# ... Also create the binary file, for use in proposals
+ARG_BIN="${ARG_FILE%.did}.bin"
+didc encode "$(cat "$ARG_FILE")" | xxd -r -p >"$ARG_BIN"
+
 ####
 # Success
 cat <<EOF
 SUCCESS: The signer argument file has been created:
-signer install args: $(sha256sum "$ARG_FILE")
+signer install args as candid: $(sha256sum "$ARG_FILE")
+signer install args as binary: $(sha256sum "$ARG_BIN")
 EOF


### PR DESCRIPTION
# Motivation
Canisters installed via proposals need their install arguments to be provided as binary, not candid.

Traditionally in other repositories this conversion has been done as part of the proposal command ([example](https://github.com/dfinity/nns-dapp/blob/main/scripts/nns-dapp/release#L129)), however that is not very reproducible, as (say) a different `didc` could theoretically yield different binary arguments.  When implementing this, we would therefore prefer to generate the binary as part of the docker build.

# Changes
- Provide binary as well as candid arguments in scripts/build.signer.args.sh
- Add the required tools for the above in the dockerfile

Note: The PR commits have been organized for easy review.

# Tests
- I have run `./scripts/docker-build` locally and verified that it produces a binary argument file (in addition to the candid argument file).
- I have verified that the contents of the binary file match the candid file (modulo formatting):
```
cat out/signer.args.bin | xxd -p | didc decode --defs src/signer/canister/signer.did --types '(Arg)'
(
  variant {
    Init = record {
      ecdsa_key_name = "key_1";
      ic_root_key_der = null;
      cycles_ledger = opt principal "um5iw-rqaaa-aaaaq-qaaba-cai";
    }
  },
)
```
