### PR TITLE
fix(devops): Print args.bin from dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -88,12 +88,13 @@ COPY scripts/build.signer.sh scripts/build.signer.args.sh scripts/
 COPY target/commit target/commit
 RUN touch src/*/src/*.rs
 RUN dfx build --ic signer
-RUN cp out/signer.wasm.gz out/signer.args.did out/signer.did /
+RUN cp out/signer.wasm.gz out/signer.args.did out/signer.args.bin out/signer.did /
 RUN cp target/commit commit
-RUN sha256sum /signer.wasm.gz /signer.args.did signer.did
+RUN sha256sum /signer.wasm.gz /signer.args.did /signer.args.bin signer.did
 
 FROM scratch AS signer
 COPY --from=build-signer /signer.wasm.gz /
 COPY --from=build-signer /signer.args.did /
+COPY --from=build-signer /signer.args.bin /
 COPY --from=build-signer /signer.did /
 COPY --from=build-signer /commit /


### PR DESCRIPTION
# Motivation
The dockerfile now creates the binary form of the canister install args, however the sha256 is not printed.

# Changes
- Print the sha256 of the binary args file.
- Provide the binary args file in the scratch output. (This is the default output; previously it was available only by specifying an earlier docker stage)

# Tests
Running through the steps for reviewing a proposal I now get:
```
SUCCESS: Docker build has succeeded.
===START_ARTEFACTS===
sha256                                                            size    filename
a99d4a8355c86d2367955d833df83302b5748e6e34898e280e359f9c57541e1f  181     out/signer.args.did
af554044ac038156017c41e85afe1898efbe773593553cf2e38584f237db1316  48      out/commit
ccd50eecb32c38fe8db74c5a84207322ca6dc4ad4c7948579a0300078c074457  8065    out/signer.did
367a11245d7e97692843c69e9582dd8ad08eef1ff3392dfd0c944d5f1bd74a41  57      out/signer.args.bin
ec022c2d6802f4622760d949f558dab2ac95dc33c68455f897ded5dfc64a62f5  461073  out/signer.wasm.gz
==END_ARTEFACTS==
```