### PR TITLE
refactor(devops): Url version

### DIFF
--- a/dev-tools.json
+++ b/dev-tools.json
@@ -2,7 +2,7 @@
 	"rustup": {
 		"method": "curl",
 		"version": "1.25.2",
-		"url": "https://raw.githubusercontent.com/rust-lang/rustup/1.25.2/rustup-init.sh",
+		"url": "https://raw.githubusercontent.com/rust-lang/rustup/${VERSION}/rustup-init.sh",
 		"pipe": [["sh"]]
 	},
 	"rust": {
@@ -12,7 +12,7 @@
 	"n": {
 		"method": "curl",
 		"version": "v9.0.1",
-		"url": "https://raw.githubusercontent.com/tj/n/refs/tags/v9.0.1/bin/n"
+		"url": "https://raw.githubusercontent.com/tj/n/refs/tags/${VERSION}/bin/n"
 	},
 	"didc": {
 		"method": "curl",

--- a/scripts/setup
+++ b/scripts/setup
@@ -8,7 +8,7 @@ for tool in "${@}"; do
   echo "  install_method: $install_method"
   case "$install_method" in
   "curl")
-    url="$(jq -r '.[env.tool].url' dev-tools.json)"
+    url="$(jq -r '.[env.tool].version as $version | .[env.tool].url | gsub("[$]{VERSION}"; $version)' dev-tools.json)"
     pipe="$(jq -r '.[env.tool].pipe // "cat"' dev-tools.json)"
     target="$HOME/.local/bin/$tool"
     mkdir -p "$(dirname "$target")"

--- a/scripts/setup
+++ b/scripts/setup
@@ -9,9 +9,10 @@ for tool in "${@}"; do
   case "$install_method" in
   "curl")
     url="$(jq -r '.[env.tool].url' dev-tools.json)"
+    pipe="$(jq -r '.[env.tool].pipe // "cat"' dev-tools.json)"
     target="$HOME/.local/bin/$tool"
     mkdir -p "$(dirname "$target")"
-    curl -Lf "$url" | install -m 755 /dev/stdin "$target"
+    curl -Lf "$url" | "$pipe" | install -m 755 /dev/stdin "$target"
     ;;
   "sh")
     version="$(jq -r '.[env.tool].version' dev-tools.json)" "$0-$tool"


### PR DESCRIPTION
# Motivation
Tool versions are often in the tool download URL.

# Changes
- Substitute `${VERSION}` for the tool version in the URL.
- Support decompression with a pipe command such as `gunzip`.

# Tests
Existing setup still works