### PR TITLE
chore(rust): Bump rust version

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
 # Please, from time to time, update this to the latest stable version on Rust Forge: https://forge.rust-lang.org/
-channel = "1.80.0"
+channel = "1.85.0"
 components = ["rustfmt", "clippy"]
 targets = [ "wasm32-unknown-unknown"]

--- a/src/signer/canister/src/sign/bitcoin/fee_utils.rs
+++ b/src/signer/canister/src/sign/bitcoin/fee_utils.rs
@@ -2,10 +2,10 @@ use ic_cdk::api::management_canister::bitcoin::{BitcoinNetwork, Utxo};
 
 use super::bitcoin_api;
 
-/// Functions stolen from [ckBTC Minter](https://github.com/dfinity/ic/blob/285a5db07da50a4e350ec43bf3b488cc6fe36102/rs/bitcoin/ckbtc/minter/src/lib.rs#L1258)
-
 /// Computes an estimate for the size of transaction (in vbytes) with the given number of inputs and
 /// outputs.
+///
+/// Functions stolen from [ckBTC Minter](https://github.com/dfinity/ic/blob/285a5db07da50a4e350ec43bf3b488cc6fe36102/rs/bitcoin/ckbtc/minter/src/lib.rs#L1258)
 fn tx_vsize_estimate(input_count: u64, output_count: u64) -> u64 {
     // See
     // [Bitcoin wiki](https://github.com/bitcoin/bips/blob/master/bip-0141.mediawiki)


### PR DESCRIPTION
# Motivation
A new version of Rust is available.

# Changes
- Update to the latest stable rust version

# Tests
Existing CI should suffice.