### PR TITLE
feat(devops): Create beta network

### DIFF
--- a/canister_ids.json
+++ b/canister_ids.json
@@ -1,10 +1,10 @@
 {
-  "example_backend": {
-    "ic": "2vxsx-fae"
-  },
-  "signer": {
-    "beta": "uhxml-hyaaa-aaaar-qaoxq-cai",
-    "ic": "grghe-syaaa-aaaar-qabyq-cai",
-    "staging": "tdxud-2yaaa-aaaad-aadiq-cai"
-  }
+	"example_backend": {
+		"ic": "2vxsx-fae"
+	},
+	"signer": {
+		"beta": "uhxml-hyaaa-aaaar-qaoxq-cai",
+		"ic": "grghe-syaaa-aaaar-qabyq-cai",
+		"staging": "tdxud-2yaaa-aaaad-aadiq-cai"
+	}
 }

--- a/canister_ids.json
+++ b/canister_ids.json
@@ -1,9 +1,10 @@
 {
-	"signer": {
-		"ic": "grghe-syaaa-aaaar-qabyq-cai",
-		"staging": "tdxud-2yaaa-aaaad-aadiq-cai"
-	},
-	"example_backend": {
-		"ic": "2vxsx-fae"
-	}
+  "example_backend": {
+    "ic": "2vxsx-fae"
+  },
+  "signer": {
+    "beta": "uhxml-hyaaa-aaaar-qaoxq-cai",
+    "ic": "grghe-syaaa-aaaar-qabyq-cai",
+    "staging": "tdxud-2yaaa-aaaad-aadiq-cai"
+  }
 }

--- a/dfx.json
+++ b/dfx.json
@@ -33,6 +33,7 @@
 			"init_arg_file": "init/bitcoin",
 			"remote": {
 				"id": {
+					"beta": "g4xu7-jiaaa-aaaan-aaaaq-cai",
 					"ic": "g4xu7-jiaaa-aaaan-aaaaq-cai"
 				}
 			}
@@ -60,6 +61,7 @@
 			"remote": {
 				"id": {
 					"staging": "um5iw-rqaaa-aaaaq-qaaba-cai",
+					"beta": "um5iw-rqaaa-aaaaq-qaaba-cai",
 					"ic": "um5iw-rqaaa-aaaaq-qaaba-cai"
 				}
 			}
@@ -80,6 +82,7 @@
 			"remote": {
 				"id": {
 					"staging": "rdmx6-jaaaa-aaaaa-aaadq-cai",
+					"beta": "rdmx6-jaaaa-aaaaa-aaadq-cai",
 					"ic": "rdmx6-jaaaa-aaaaa-aaadq-cai"
 				}
 			},
@@ -96,6 +99,10 @@
 	"version": 1,
 	"networks": {
 		"staging": {
+			"providers": ["https://icp0.io"],
+			"type": "persistent"
+		},
+		"beta": {
 			"providers": ["https://icp0.io"],
 			"type": "persistent"
 		}


### PR DESCRIPTION
# Motivation
It is useful to have a test canister running on the same subnet as production, to get accurate pricing and behaviour metrics.

The staging canister operates on a different subnet, and is used extensively by projects other than the chain fusion signer project itself, making it hard to get precise measurements from that canister.

# Changes
- Define a new beta environment
- Create a new signer canister, on the same subnet as production.

# Tests
## Claim: The beta canister is on the same subnet as production.
This can be checked by comparing the subnets on the dashboard.

Beta: https://dashboard.internetcomputer.org/canister/uhxml-hyaaa-aaaar-qaoxq-cai
Prod: https://dashboard.internetcomputer.org/canister/grghe-syaaa-aaaar-qabyq-cai

## Claim: The new canister is supplied with cycles
The new canister is configured in cycleops under our team account.

## Claim: The team has control over the canister
The canister has Orbit as a controller.