### PR TITLE
fix(devops): ENV -> DFX_NETWORK

### DIFF
--- a/scripts/build.signer.args.sh
+++ b/scripts/build.signer.args.sh
@@ -42,7 +42,7 @@ case "$DFX_NETWORK" in
   # to match what candid expects ({}), replace the commas between array entries to match
   # what candid expects (semicolon) and annotate the numbers with their type (otherwise dfx assumes 'nat'
   # instead of 'nat8').
-  rootkey_did=$(dfx ping "${ENV:-local}" |
+  rootkey_did=$(dfx ping "${DFX_NETWORK:-local}" |
     jq -r '.root_key | reduce .[] as $item ("{ "; "\(.) \($item):nat8;") + " }"')
   echo "Parsed rootkey: ${rootkey_did:0:20}..." >&2
   ic_root_key_der="opt vec $rootkey_did"


### PR DESCRIPTION
# Motivation
We now have a beta network for the chain fusion signer, but `dfx build signer --network beta` fails.

The deploy code works for `local`, `staging` and `ic` but not for other networks.  

There is a match clause that deals with `ic`, `staging` and everything else.  The branch for "everything else" gets the network from "ENV", defaulting to `local` if `ENV` is not defined.  So it worked for local but not for `beta`.  The `ENV` should be `DFX_NETWORK`.

`beta` will actually be grouped with `ic` in that match clause, however given that the bug has been spotted we might as well use beta to fix that code path first.

# Changes
- Correct `ENV` to `DFX_NETWORK`.


# Tests

`dfx build signer --network beta` now works.