### PR TITLE
chore(devops): Update GitHub actions automagically

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,10 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    schedule:
+      interval: weekly
   - package-ecosystem: "npm"
     directory: "/"
     schedule:


### PR DESCRIPTION
# Motivation
It is desirable to specify GitHub actions by commit rather than by tag, to protect against the tag being moved.  However this makes updates tedious.  Dependabot can help wit hthis.

# Changes
- Enable dependabot updates for GitHub actions.

# Tests

<!-- Please provide any information or screenshots about the tests that have been done -->
