### PR TITLE
chore(devops): Use ubuntu 24.04 throughout

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -11,7 +11,7 @@ defaults:
 jobs:
   format:
     name: 'Format'
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     env:
       TITLE: ${{ github.event.pull_request.title }}
     steps:
@@ -30,7 +30,7 @@ jobs:
           }
   sh-tests:
     name: "Shell tests"
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -53,7 +53,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-22.04]
+        os: [ubuntu-24.04]
     steps:
       - uses: actions/checkout@v4
       - name: Have relevant files changed?
@@ -86,7 +86,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-22.04]
+        os: [ubuntu-24.04]
     steps:
       - uses: actions/checkout@v4
       - name: Have relevant files changed?
@@ -136,7 +136,7 @@ jobs:
     name: "Checks pass"
     needs: ["format", "rust-tests", "sh-tests", "installation"]
     if: ${{ always() }}
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/needs_success

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   pr:
     name: 'PR'
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     env:
       TITLE: ${{ github.event.pull_request.title }}
     steps:
@@ -29,7 +29,7 @@ jobs:
   pr-pass:
     needs: ["pr"]
     if: ${{ always() }}
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/needs_success

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ defaults:
     shell: bash -euxlo pipefail {0}
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 45
     env:
       GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/reproducible-native.yaml
+++ b/.github/workflows/reproducible-native.yaml
@@ -21,7 +21,7 @@ jobs:
         os:
           - macos-13
           - macos-14
-          - ubuntu-24.04
+          - ubuntu-22.04
           - ubuntu-24.04
     steps:
       - name: Unbork mac

--- a/.github/workflows/reproducible-native.yaml
+++ b/.github/workflows/reproducible-native.yaml
@@ -21,7 +21,7 @@ jobs:
         os:
           - macos-13
           - macos-14
-          - ubuntu-22.04
+          - ubuntu-24.04
           - ubuntu-24.04
     steps:
       - name: Unbork mac
@@ -58,7 +58,7 @@ jobs:
           name: hashes_${{ matrix.os }}
           path: hashes/*.txt
   compare_hashes:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs: [build]
     if: ${{ always() }}
     steps:
@@ -80,7 +80,7 @@ jobs:
   reproducible_build_passes:
     needs: ["build", "compare_hashes"]
     if: ${{ always() }}
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/needs_success

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # Reproducible Builds
 #
 
-FROM ubuntu:22.04 AS base
+FROM ubuntu:24.04 AS base
 ENV TZ=UTC
 # Install basic tools
 RUN DEBIAN_FRONTEND=noninteractive apt update && apt install -y \


### PR DESCRIPTION
# Motivation
GitHub is starting to remove 20.04 runners.

# Changes
- Use Ubuntu 24.04 throughout

# Tests
For GitHub workflows: See CI

For docker builds: 
```
$ ./scripts/docker-build
...
SUCCESS: Docker build has succeeded.                                                                                                                                                                                                                                                                                                                                                                                             
                                                                                                                                                                                                                                                                                                                                                                                                                                 
Assets:                                                                                                                                                                                                                                                                                                                                                                                                                          
367a11245d7e97692843c69e9582dd8ad08eef1ff3392dfd0c944d5f1bd74a41  out/signer.args.bin
a99d4a8355c86d2367955d833df83302b5748e6e34898e280e359f9c57541e1f  out/signer.args.did
670c4eabb71389e089064d19d2b8ec95573dfacbf8ba1fe12481468b784571e3  out/signer.args.hex
ccd50eecb32c38fe8db74c5a84207322ca6dc4ad4c7948579a0300078c074457  out/signer.did
1fb4f6f4a6ef18137229ee8234f14dd6039242d8e4154bf08de072a7cf82a496  out/signer.wasm.gz
```