### PR TITLE
chore(devops): Bump ic-admin

### DIFF
--- a/dev-tools.json
+++ b/dev-tools.json
@@ -20,7 +20,7 @@
 		"url": "https://github.com/dfinity/candid/releases/download/2024-07-29/didc-linux64"
 	},
 	"ic-admin": {
-		"version": "release-2024-12-06_03-16-base",
+		"version": "release-2025-03-20_03-11-base",
 		"method": "curl",
 		"pipe": "gunzip",
 		"url": "https://github.com/dfinity/ic/releases/download/${VERSION}/ic-admin-x86_64-linux.gz"


### PR DESCRIPTION
# Motivation
It was mentioned during the last release, in December, that the latest `ic-admin` had nice additional features.  The `ic-admin` was already quite new, but let's make sure that we have the desired behaviour.

# Changes
- Update `ic-admin` to the latest version.

# Tests
Existing CI should suffice.