### PR TITLE
chore(devops): Bump tarpaulin

### DIFF
--- a/dev-tools.json
+++ b/dev-tools.json
@@ -69,6 +69,6 @@
 	},
 	"cargo-tarpaulin": {
 		"method": "cargo-binstall",
-		"version": "0.26.1"
+		"version": "0.32.3"
 	}
 }


### PR DESCRIPTION
# Motivation
A newer version of tarpaulin, the rust unit test coverage tool, is available.

# Changes
- Update tarpaulin.

# Tests
Existing CI should suffice