### PR TITLE
chore(release): Bump version to 0.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -787,7 +787,7 @@ dependencies = [
 
 [[package]]
 name = "example_backend"
-version = "0.2.8"
+version = "0.4.0"
 dependencies = [
  "candid",
  "ic-cdk 0.20.1",
@@ -1343,7 +1343,7 @@ dependencies = [
 
 [[package]]
 name = "ic-chain-fusion-signer-api"
-version = "0.2.8"
+version = "0.4.0"
 dependencies = [
  "candid",
  "ic-canister-sig-creation",
@@ -2840,7 +2840,7 @@ dependencies = [
 
 [[package]]
 name = "signer"
-version = "0.2.8"
+version = "0.4.0"
 dependencies = [
  "assert_matches",
  "bitcoin",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,9 @@ members = [
     "src/signer/canister"]
 resolver = "2"
 
+[workspace.package]
+version = "0.4.0"
+
 [workspace.dependencies]
 assert_matches = "1.5.0"
 ic-cdk = "0.20.1"

--- a/src/example_backend/Cargo.toml
+++ b/src/example_backend/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "example_backend"
-version = "0.2.8"
+version = "0.4.0"
 edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/src/example_backend/Cargo.toml
+++ b/src/example_backend/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "example_backend"
-version.workspace = true
+version = { workspace = true }
 edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/src/example_backend/Cargo.toml
+++ b/src/example_backend/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "example_backend"
-version = "0.4.0"
+version.workspace = true
 edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/src/signer/api/Cargo.toml
+++ b/src/signer/api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ic-chain-fusion-signer-api"
-version.workspace = true
+version = { workspace = true }
 edition = "2021"
 
 [dependencies]

--- a/src/signer/api/Cargo.toml
+++ b/src/signer/api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ic-chain-fusion-signer-api"
-version = "0.2.8"
+version = "0.4.0"
 edition = "2021"
 
 [dependencies]

--- a/src/signer/api/Cargo.toml
+++ b/src/signer/api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ic-chain-fusion-signer-api"
-version = "0.4.0"
+version.workspace = true
 edition = "2021"
 
 [dependencies]

--- a/src/signer/canister/Cargo.toml
+++ b/src/signer/canister/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "signer"
-version.workspace = true
+version = { workspace = true }
 edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/src/signer/canister/Cargo.toml
+++ b/src/signer/canister/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "signer"
-version = "0.2.8"
+version = "0.4.0"
 edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/src/signer/canister/Cargo.toml
+++ b/src/signer/canister/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "signer"
-version = "0.4.0"
+version.workspace = true
 edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
# Motivation
We would like to make the 0.4.0 release. The in-code crate versions had drifted from the released tags (still at `0.2.8` despite `v0.2.9` and `v0.3.0` having been tagged). This bumps them to `0.4.0` and, to prevent the drift from recurring, switches the workspace to a single shared version.

# Changes
- Add `[workspace.package] version = "0.4.0"` to the root `Cargo.toml` as the single source of truth.
- Set `version.workspace = true` in all three crates (`signer`, `ic-chain-fusion-signer-api`, `example_backend`), which had always been kept in lockstep anyway.
- Regenerate `Cargo.lock`.

Future releases are now a one-line bump in the root manifest.

# Tests
N/A