### PR TITLE
chore(release): Bump version to 0.4.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -787,7 +787,7 @@ dependencies = [
 
 [[package]]
 name = "example_backend"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "candid",
  "ic-cdk 0.20.2",
@@ -1343,7 +1343,7 @@ dependencies = [
 
 [[package]]
 name = "ic-chain-fusion-signer-api"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "candid",
  "ic-canister-sig-creation",
@@ -2840,7 +2840,7 @@ dependencies = [
 
 [[package]]
 name = "signer"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "assert_matches",
  "bitcoin",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.4.0"
+version = "0.4.1"
 
 [workspace.dependencies]
 assert_matches = "1.5.0"


### PR DESCRIPTION
# Motivation

We would like to make the `0.4.1` release. Since `v0.4.0`, the most notable change is the strict DER encoding fix for Bitcoin signatures (#514), alongside a batch of dependency updates.

The workspace version is the single source of truth (`[workspace.package]` in the root `Cargo.toml`), so this is a one-line bump plus the regenerated `Cargo.lock`.

# Changes

- Bump the workspace version from `0.4.0` to `0.4.1` in the root `Cargo.toml` (inherited by `signer`, `ic-chain-fusion-signer-api`, and `example_backend`).
- Regenerate `Cargo.lock`.

# Tests

N/A — version-only bump.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code) (Opus 4.8)