### PR TITLE
chore(ci): Automate the release and deploy flow with chained workflows

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -1,5 +1,4 @@
 name: Version Bump and Release Branch Creation
-
 on:
   workflow_dispatch:
     inputs:
@@ -15,13 +14,10 @@ on:
           - alpha
           - beta
           - rc
-
 permissions: {}
-
 defaults:
   run:
     shell: bash -euxlo pipefail {0}
-
 jobs:
   version_bump:
     runs-on: ubuntu-24.04
@@ -35,15 +31,12 @@ jobs:
         with:
           app-id: ${{ vars.PR_AUTOMATION_BOT_PUBLIC_APP_ID }}
           private-key: ${{ secrets.PR_AUTOMATION_BOT_PUBLIC_PRIVATE_KEY }}
-
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
-
       - name: Install build tools
         run: scripts/setup cargo-binstall cargo-edit
-
       - name: Bump version
         id: bump_version
         run: |
@@ -53,7 +46,6 @@ jobs:
           echo "Bumped to version: $new_version"
         env:
           VERSION_BUMP: ${{ github.event.inputs.version_bump }}
-
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@6d6857d36972b65feb161a90e484f2984215f83e # v6.0.5
         with:

--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -1,0 +1,73 @@
+name: Version Bump and Release Branch Creation
+
+on:
+  workflow_dispatch:
+    inputs:
+      version_bump:
+        description: 'Version bump type'
+        required: true
+        default: 'patch'
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+          - alpha
+          - beta
+          - rc
+
+permissions: {}
+
+defaults:
+  run:
+    shell: bash -euxlo pipefail {0}
+
+jobs:
+  version_bump:
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Create GitHub App Token
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+        id: app-token
+        with:
+          app-id: ${{ vars.PR_AUTOMATION_BOT_PUBLIC_APP_ID }}
+          private-key: ${{ secrets.PR_AUTOMATION_BOT_PUBLIC_PRIVATE_KEY }}
+
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - name: Install build tools
+        run: scripts/setup cargo-binstall cargo-edit
+
+      - name: Bump version
+        id: bump_version
+        run: |
+          ./scripts/version-bump "$VERSION_BUMP"
+          new_version="$(cargo metadata --format-version 1 --no-deps | jq -r '.packages[] | select(.name == "signer") | .version')"
+          echo "new_version=$new_version" >> "$GITHUB_OUTPUT"
+          echo "Bumped to version: $new_version"
+        env:
+          VERSION_BUMP: ${{ github.event.inputs.version_bump }}
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@6d6857d36972b65feb161a90e484f2984215f83e # v6.0.5
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          base: main
+          branch: release/v${{ steps.bump_version.outputs.new_version }}
+          delete-branch: true
+          commit-message: 'chore(release): Bump version to ${{ steps.bump_version.outputs.new_version }}'
+          committer: GitHub <noreply@github.com>
+          title: 'chore(release): Bump version to ${{ steps.bump_version.outputs.new_version }}'
+          body: |
+            This PR prepares the release of version v${{ steps.bump_version.outputs.new_version }}.
+
+            On merge, the [Tag on Merge from Release Branch](.github/workflows/tag-release.yml) workflow will:
+
+            - Tag the merge commit with `v${{ steps.bump_version.outputs.new_version }}`, which triggers the [Release](.github/workflows/release.yml) workflow to build and attach the release artifacts.
+            - Deploy the signer to `staging`.

--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -59,7 +59,4 @@ jobs:
           body: |
             This PR prepares the release of version v${{ steps.bump_version.outputs.new_version }}.
 
-            On merge, the [Tag on Merge from Release Branch](.github/workflows/tag-release.yml) workflow will:
-
-            - Tag the merge commit with `v${{ steps.bump_version.outputs.new_version }}`, which triggers the [Release](.github/workflows/release.yml) workflow to build and attach the release artifacts.
-            - Deploy the signer to `staging`.
+            On merge, the [Tag on Merge from Release Branch](.github/workflows/tag-release.yml) workflow will tag the merge commit with `v${{ steps.bump_version.outputs.new_version }}`, which triggers the [Release](.github/workflows/release.yml) workflow to build and attach the release artifacts. On completion, the [Deploy to Staging](.github/workflows/deploy-staging.yml) workflow deploys those artifacts to `staging`.

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -1,5 +1,4 @@
 name: Deploy to Staging
-
 on:
   workflow_dispatch:
   workflow_call:
@@ -12,20 +11,15 @@ on:
     secrets:
       DFX_DEPLOY_KEY_STAGING:
         required: true
-
 permissions: {}
-
 concurrency:
   group: ${{ github.workflow }}
   cancel-in-progress: false
-
 defaults:
   run:
     shell: bash -euxlo pipefail {0}
-
 env:
   DFX_WARNING: '-mainnet_plaintext_identity'
-
 jobs:
   deploy:
     runs-on: ubuntu-24.04
@@ -38,13 +32,10 @@ jobs:
         with:
           ref: ${{ inputs.ref }}
           persist-credentials: false
-
       - name: Build reproducibly
         uses: ./.github/actions/build
-
       - name: Install dfx
         uses: dfinity/setup-dfx@e50c04f104ee4285ec010f10609483cf41e4d365 # main
-
       - name: Import deployment identity
         run: |
           key_pem=$(mktemp)
@@ -55,10 +46,8 @@ jobs:
           dfx identity get-principal
         env:
           DFX_DEPLOY_KEY: ${{ secrets.DFX_DEPLOY_KEY_STAGING }}
-
       - name: Deploy signer to staging
         run: dfx canister install signer --mode upgrade --upgrade-unchanged --network staging --yes
-
       - name: Verify deployment
         run: |
           sha256sum out/signer.wasm.gz

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -1,0 +1,66 @@
+name: Deploy to Staging
+
+on:
+  workflow_dispatch:
+  workflow_call:
+    inputs:
+      ref:
+        description: 'The git ref to build and deploy. Defaults to the ref that triggered the workflow.'
+        required: false
+        type: string
+        default: ''
+    secrets:
+      DFX_DEPLOY_KEY_STAGING:
+        required: true
+
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
+defaults:
+  run:
+    shell: bash -euxlo pipefail {0}
+
+env:
+  DFX_WARNING: '-mainnet_plaintext_identity'
+
+jobs:
+  deploy:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 60
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          ref: ${{ inputs.ref }}
+          persist-credentials: false
+
+      - name: Build reproducibly
+        uses: ./.github/actions/build
+
+      - name: Install dfx
+        uses: dfinity/setup-dfx@e50c04f104ee4285ec010f10609483cf41e4d365 # main
+
+      - name: Import deployment identity
+        run: |
+          key_pem=$(mktemp)
+          printenv DFX_DEPLOY_KEY > "$key_pem"
+          dfx identity import --storage-mode=plaintext --force deploy "$key_pem"
+          rm "$key_pem"
+          dfx identity use deploy
+          dfx identity get-principal
+        env:
+          DFX_DEPLOY_KEY: ${{ secrets.DFX_DEPLOY_KEY_STAGING }}
+
+      - name: Deploy signer to staging
+        run: dfx canister install signer --mode upgrade --upgrade-unchanged --network staging --yes
+
+      - name: Verify deployment
+        run: |
+          sha256sum out/signer.wasm.gz
+          dfx canister info signer --network staging
+          dfx canister metadata signer git:commit --network staging

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -54,7 +54,11 @@ jobs:
         env:
           DFX_DEPLOY_KEY: ${{ secrets.DFX_DEPLOY_KEY_STAGING }}
       - name: Deploy signer to staging
-        run: dfx canister install signer --mode upgrade --upgrade-unchanged --network staging --yes
+        # The build artifacts contain the init args for DFX_NETWORK=ic, which
+        # do not apply to staging. Pass an explicit Upgrade argument so that
+        # post_upgrade preserves the existing staging configuration instead of
+        # applying the ic init args.
+        run: dfx canister install signer --mode upgrade --upgrade-unchanged --argument '(variant { Upgrade })' --network staging --yes
       - name: Verify deployment
         run: |
           sha256sum out/signer.wasm.gz

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -1,16 +1,12 @@
 name: Deploy to Staging
 on:
+  # Auto-deploy a release: when the Release workflow has built the artifacts
+  # for a v* tag, deploy exactly those artifacts to staging.
+  workflow_run:
+    workflows: ['Release']
+    types: [completed]
+  # Manual deployment of any ref, from a fresh reproducible build.
   workflow_dispatch:
-  workflow_call:
-    inputs:
-      ref:
-        description: 'The git ref to build and deploy. Defaults to the ref that triggered the workflow.'
-        required: false
-        type: string
-        default: ''
-    secrets:
-      DFX_DEPLOY_KEY_STAGING:
-        required: true
 permissions: {}
 concurrency:
   group: ${{ github.workflow }}
@@ -22,17 +18,28 @@ env:
   DFX_WARNING: '-mainnet_plaintext_identity'
 jobs:
   deploy:
+    if: github.event_name == 'workflow_dispatch' || (github.event.workflow_run.conclusion == 'success' && startsWith(github.event.workflow_run.head_branch, 'v'))
     runs-on: ubuntu-24.04
     timeout-minutes: 60
     permissions:
       contents: read
+      actions: read
     steps:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
-          ref: ${{ inputs.ref }}
+          ref: ${{ github.event.workflow_run.head_sha || github.ref }}
           persist-credentials: false
+      - name: Get release artifacts
+        if: github.event_name == 'workflow_run'
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: release-artifacts
+          path: out
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ github.token }}
       - name: Build reproducibly
+        if: github.event_name == 'workflow_dispatch'
         uses: ./.github/actions/build
       - name: Install dfx
         uses: dfinity/setup-dfx@e50c04f104ee4285ec010f10609483cf41e4d365 # main

--- a/.github/workflows/prepare-proposal.yml
+++ b/.github/workflows/prepare-proposal.yml
@@ -1,5 +1,4 @@
 name: Prepare Production Proposal
-
 on:
   workflow_dispatch:
     inputs:
@@ -7,17 +6,13 @@ on:
         description: 'The release tag to prepare a proposal for, e.g. v0.4.1. The release must be published.'
         required: true
         type: string
-
 permissions: {}
-
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.inputs.tag }}
   cancel-in-progress: true
-
 defaults:
   run:
     shell: bash -euxlo pipefail {0}
-
 jobs:
   prepare:
     runs-on: ubuntu-24.04
@@ -34,13 +29,10 @@ jobs:
           ref: ${{ github.event.inputs.tag }}
           fetch-depth: 0
           persist-credentials: false
-
       - name: Get release assets
         run: ./scripts/proposal-assets -t "$TAG"
-
       - name: Build reproducibly
         uses: ./.github/actions/build
-
       - name: Verify that the release assets match the reproducible build
         run: |
           for asset in signer.wasm.gz signer.args.did signer.args.bin; do
@@ -52,13 +44,10 @@ jobs:
             fi
             echo "OK: $asset $release_hash"
           done
-
       - name: Install dfx
         uses: dfinity/setup-dfx@e50c04f104ee4285ec010f10609483cf41e4d365 # main
-
       - name: Create proposal template
         run: ./scripts/proposal-template -t "$TAG"
-
       - name: Summarize
         run: |
           {
@@ -70,7 +59,6 @@ jobs:
             echo
             echo "To submit, download the \`proposal-$TAG\` artifact into \`release/\`, install \`ic-admin\` with \`./scripts/setup ic-admin\` and run \`./scripts/propose\`."
           } >> "$GITHUB_STEP_SUMMARY"
-
       - name: Upload proposal artifacts
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:

--- a/.github/workflows/prepare-proposal.yml
+++ b/.github/workflows/prepare-proposal.yml
@@ -1,0 +1,79 @@
+name: Prepare Production Proposal
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'The release tag to prepare a proposal for, e.g. v0.4.1. The release must be published.'
+        required: true
+        type: string
+
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.inputs.tag }}
+  cancel-in-progress: true
+
+defaults:
+  run:
+    shell: bash -euxlo pipefail {0}
+
+jobs:
+  prepare:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 60
+    permissions:
+      contents: read
+    env:
+      GH_TOKEN: ${{ github.token }}
+      TAG: ${{ github.event.inputs.tag }}
+    steps:
+      - name: Checkout release tag
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          ref: ${{ github.event.inputs.tag }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Get release assets
+        run: ./scripts/proposal-assets -t "$TAG"
+
+      - name: Build reproducibly
+        uses: ./.github/actions/build
+
+      - name: Verify that the release assets match the reproducible build
+        run: |
+          for asset in signer.wasm.gz signer.args.did signer.args.bin; do
+            release_hash="$(sha256sum "release/ci/$asset" | awk '{print $1}')"
+            build_hash="$(sha256sum "out/$asset" | awk '{print $1}')"
+            if [[ "$release_hash" != "$build_hash" ]]; then
+              echo "ERROR: Hash mismatch for $asset: release=$release_hash build=$build_hash"
+              exit 1
+            fi
+            echo "OK: $asset $release_hash"
+          done
+
+      - name: Install dfx
+        uses: dfinity/setup-dfx@e50c04f104ee4285ec010f10609483cf41e4d365 # main
+
+      - name: Create proposal template
+        run: ./scripts/proposal-template -t "$TAG"
+
+      - name: Summarize
+        run: |
+          {
+            echo "## Proposal for \`$TAG\`"
+            echo
+            echo '```'
+            cat release/PROPOSAL.md
+            echo '```'
+            echo
+            echo "To submit, download the \`proposal-$TAG\` artifact into \`release/\`, install \`ic-admin\` with \`./scripts/setup ic-admin\` and run \`./scripts/propose\`."
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload proposal artifacts
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: proposal-${{ github.event.inputs.tag }}
+          path: release/
+          if-no-files-found: error

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,6 +29,14 @@ jobs:
         run: git tag --points-at HEAD
       - name: Build
         uses: ./.github/actions/build
+      - name: Upload build outputs
+        # Used by the "Deploy to Staging" workflow, so that it deploys
+        # exactly the artifacts that were released.
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: release-artifacts
+          path: out/
+          if-no-files-found: error
       - name: Release
         run: |
           for tag in $(git tag --points-at HEAD) ; do

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -1,17 +1,13 @@
 name: Tag on Merge from Release Branch
-
 on:
   pull_request:
     types: [closed]
     branches:
       - main
-
 permissions: {}
-
 defaults:
   run:
     shell: bash -euxlo pipefail {0}
-
 jobs:
   tag:
     if: github.event.pull_request.merged == true && startsWith(github.event.pull_request.head.ref, 'release/v')
@@ -25,20 +21,17 @@ jobs:
         with:
           app-id: ${{ vars.PR_AUTOMATION_BOT_PUBLIC_APP_ID }}
           private-key: ${{ secrets.PR_AUTOMATION_BOT_PUBLIC_PRIVATE_KEY }}
-
       - name: Checkout merge commit
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           ref: ${{ github.event.pull_request.merge_commit_sha }}
           persist-credentials: false
-
       - name: Get version from Cargo metadata
         id: get_version
         run: |
           version="$(cargo metadata --format-version 1 --no-deps | jq -r '.packages[] | select(.name == "signer") | .version')"
           echo "Version: $version"
           echo "version=$version" >> "$GITHUB_OUTPUT"
-
       - name: Create Git tag
         # Pushing the tag with the app token triggers the Release workflow,
         # which builds the artifacts and creates the GitHub release.
@@ -50,7 +43,6 @@ jobs:
         env:
           VERSION: ${{ steps.get_version.outputs.version }}
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
-
   call-deploy-staging:
     needs: tag
     if: needs.tag.result == 'success'

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -38,6 +38,8 @@ jobs:
         # Release workflow completes, the Deploy to Staging workflow deploys
         # the release artifacts to staging.
         run: |
+          # Disable xtrace so that the token is not expanded into the logs.
+          set +x
           git config url."https://github-actions:$GITHUB_TOKEN@github.com/".insteadOf "https://github.com/"
           git tag "v$VERSION"
           git push origin "refs/tags/v$VERSION"

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -34,7 +34,9 @@ jobs:
           echo "version=$version" >> "$GITHUB_OUTPUT"
       - name: Create Git tag
         # Pushing the tag with the app token triggers the Release workflow,
-        # which builds the artifacts and creates the GitHub release.
+        # which builds the artifacts and creates the GitHub release. When the
+        # Release workflow completes, the Deploy to Staging workflow deploys
+        # the release artifacts to staging.
         run: |
           git config url."https://github-actions:$GITHUB_TOKEN@github.com/".insteadOf "https://github.com/"
           git tag "v$VERSION"
@@ -43,13 +45,3 @@ jobs:
         env:
           VERSION: ${{ steps.get_version.outputs.version }}
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
-  call-deploy-staging:
-    needs: tag
-    if: needs.tag.result == 'success'
-    permissions:
-      contents: read
-    uses: ./.github/workflows/deploy-staging.yml
-    with:
-      ref: ${{ github.event.pull_request.merge_commit_sha }}
-    secrets:
-      DFX_DEPLOY_KEY_STAGING: ${{ secrets.DFX_DEPLOY_KEY_STAGING }}

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -1,0 +1,63 @@
+name: Tag on Merge from Release Branch
+
+on:
+  pull_request:
+    types: [closed]
+    branches:
+      - main
+
+permissions: {}
+
+defaults:
+  run:
+    shell: bash -euxlo pipefail {0}
+
+jobs:
+  tag:
+    if: github.event.pull_request.merged == true && startsWith(github.event.pull_request.head.ref, 'release/v')
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: write
+    steps:
+      - name: Create GitHub App Token
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+        id: app-token
+        with:
+          app-id: ${{ vars.PR_AUTOMATION_BOT_PUBLIC_APP_ID }}
+          private-key: ${{ secrets.PR_AUTOMATION_BOT_PUBLIC_PRIVATE_KEY }}
+
+      - name: Checkout merge commit
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          ref: ${{ github.event.pull_request.merge_commit_sha }}
+          persist-credentials: false
+
+      - name: Get version from Cargo metadata
+        id: get_version
+        run: |
+          version="$(cargo metadata --format-version 1 --no-deps | jq -r '.packages[] | select(.name == "signer") | .version')"
+          echo "Version: $version"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
+      - name: Create Git tag
+        # Pushing the tag with the app token triggers the Release workflow,
+        # which builds the artifacts and creates the GitHub release.
+        run: |
+          git config url."https://github-actions:$GITHUB_TOKEN@github.com/".insteadOf "https://github.com/"
+          git tag "v$VERSION"
+          git push origin "refs/tags/v$VERSION"
+          git config --unset-all url."https://github-actions:$GITHUB_TOKEN@github.com/".insteadOf || true
+        env:
+          VERSION: ${{ steps.get_version.outputs.version }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+
+  call-deploy-staging:
+    needs: tag
+    if: needs.tag.result == 'success'
+    permissions:
+      contents: read
+    uses: ./.github/workflows/deploy-staging.yml
+    with:
+      ref: ${{ github.event.pull_request.merge_commit_sha }}
+    secrets:
+      DFX_DEPLOY_KEY_STAGING: ${{ secrets.DFX_DEPLOY_KEY_STAGING }}

--- a/HACKING.md
+++ b/HACKING.md
@@ -34,7 +34,7 @@ For a production release, the flow is automated by chained GitHub actions:
 - Review and merge the release PR.
 - On merge, the [Tag on Merge from Release Branch](.github/workflows/tag-release.yml) workflow tags the merge commit with `v<version>`, which in turn triggers:
   - The [Release](.github/workflows/release.yml) workflow, which builds the artifacts and creates a draft GitHub release.
-  - The [Deploy to Staging](.github/workflows/deploy-staging.yml) workflow, which deploys the new version to `staging` (see below).
+  - On completion of the Release workflow, the [Deploy to Staging](.github/workflows/deploy-staging.yml) workflow, which deploys the release artifacts to `staging` (see below).
 - Sanity check the release artifacts.
 - Write some release notes for the GitHub release, if you wish.
 - Make the release public.
@@ -56,7 +56,7 @@ The same can be done by hand:
 
 ## Deploy to `staging`
 
-Merging a release PR deploys the new version to `staging` automatically, via the [Deploy to Staging](.github/workflows/deploy-staging.yml) workflow. The same workflow can also be triggered manually from the GitHub Actions tab to deploy any ref. It makes a reproducible docker build and upgrades the canister with the `DFX_DEPLOY_KEY_STAGING` identity, which must be a controller of the staging canister.
+Merging a release PR deploys the new version to `staging` automatically, via the [Deploy to Staging](.github/workflows/deploy-staging.yml) workflow. It runs when the [Release](.github/workflows/release.yml) workflow completes successfully for a `v*` tag and deploys exactly the artifacts built by that release. The workflow can also be triggered manually from the GitHub Actions tab to deploy any ref, in which case it makes a fresh reproducible docker build. Either way, the canister is upgraded with the `DFX_DEPLOY_KEY_STAGING` identity, which must be a controller of the staging canister.
 
 Alternatively, by hand: if you are a controller of the staging canister, a quick release can be made with:
 

--- a/HACKING.md
+++ b/HACKING.md
@@ -56,7 +56,7 @@ The same can be done by hand:
 
 ## Deploy to `staging`
 
-Merging a release PR deploys the new version to `staging` automatically, via the [Deploy to Staging](.github/workflows/deploy-staging.yml) workflow. It runs when the [Release](.github/workflows/release.yml) workflow completes successfully for a `v*` tag and deploys exactly the artifacts built by that release. The workflow can also be triggered manually from the GitHub Actions tab to deploy any ref, in which case it makes a fresh reproducible docker build. Either way, the canister is upgraded with the `DFX_DEPLOY_KEY_STAGING` identity, which must be a controller of the staging canister.
+Merging a release PR deploys the new version to `staging` automatically, via the [Deploy to Staging](.github/workflows/deploy-staging.yml) workflow. It runs when the [Release](.github/workflows/release.yml) workflow completes successfully for a `v*` tag and deploys exactly the Wasm built by that release. Note that the release artifacts are built for the `ic` network, so the workflow passes an explicit `Upgrade` argument to preserve the existing staging configuration instead of installing the `ic` init args. The workflow can also be triggered manually from the GitHub Actions tab to deploy any ref, in which case it makes a fresh reproducible docker build. Either way, the canister is upgraded with the `DFX_DEPLOY_KEY_STAGING` identity, which must be a controller of the staging canister.
 
 Alternatively, by hand: if you are a controller of the staging canister, a quick release can be made with:
 

--- a/HACKING.md
+++ b/HACKING.md
@@ -27,7 +27,21 @@ Releases are created by a GitHub action.
 
 For a test release, just push any tag and a release will be created for that tag.
 
-For a production release:
+For a production release, the flow is automated by chained GitHub actions:
+
+- Trigger the [Version Bump and Release Branch Creation](.github/workflows/bump-version.yml) workflow from the GitHub Actions tab, choosing the bump type (`patch|minor|major|alpha|beta|rc`).
+  - This runs `./scripts/version-bump` and opens a release PR from a `release/v*` branch.
+- Review and merge the release PR.
+- On merge, the [Tag on Merge from Release Branch](.github/workflows/tag-release.yml) workflow tags the merge commit with `v<version>`, which in turn triggers:
+  - The [Release](.github/workflows/release.yml) workflow, which builds the artifacts and creates a draft GitHub release.
+  - The [Deploy to Staging](.github/workflows/deploy-staging.yml) workflow, which deploys the new version to `staging` (see below).
+- Sanity check the release artifacts.
+- Write some release notes for the GitHub release, if you wish.
+- Make the release public.
+
+### Manual release
+
+The same can be done by hand:
 
 - Ensure that you have the development tools listed in `dev-tools.json` installed on your machine. In particular, you may need:
   - `./scripts/setup cargo-edit`
@@ -42,7 +56,9 @@ For a production release:
 
 ## Deploy to `staging`
 
-If you are a controller of the staging canister, a quick release can be made with:
+Merging a release PR deploys the new version to `staging` automatically, via the [Deploy to Staging](.github/workflows/deploy-staging.yml) workflow. The same workflow can also be triggered manually from the GitHub Actions tab to deploy any ref. It makes a reproducible docker build and upgrades the canister with the `DFX_DEPLOY_KEY_STAGING` identity, which must be a controller of the staging canister.
+
+Alternatively, by hand: if you are a controller of the staging canister, a quick release can be made with:
 
 ```
 dfx deploy signer --network staging
@@ -69,6 +85,19 @@ If you are not a controller, you may request a canister upgrade via Orbit. Pleas
 - Create a GitHub release with a tag such as `v0.1.2`
   - Update the GitHub release text. It is recommended to ask the team to review the text.
   - Ensure that the release has been published.
+- Trigger the [Prepare Production Proposal](.github/workflows/prepare-proposal.yml) workflow from the GitHub Actions tab with the release tag. It will:
+  - Download the release Wasm and arguments to `release/ci`.
+  - Run a reproducible docker build and verify that the Wasm and argument file hashes match the release assets.
+  - Create `release/PROPOSAL.md` and `release/ROLLBACK.md` and upload them, together with the release assets, as a workflow artifact.
+- Check out the release commit.
+- Delete any old release directory and download the `proposal-$TAG` workflow artifact into `release/`.
+- Install the corresponding `ic-admin`: `./scripts/setup ic-admin`
+- Run: `./scripts/propose`
+  - Verify the proposal very carefully, then submit the proposal.
+- Create an appointment with trusted neurons to vote on the proposal.
+
+The same can be done by hand:
+
 - Check out the release commit
 - Delete any old release directory.
 - Install the corresponding `ic-admin`: `./scripts/setup ic-admin`


### PR DESCRIPTION
# Motivation

`HACKING.md` describes a fully manual release and deploy flow: bump the version locally, open a release branch, tag by hand, deploy to staging from a laptop, and assemble the production proposal step by step. We already automate the equivalent flow in [oisy-wallet](https://github.com/dfinity/oisy-wallet) with chained GitHub workflows, so this PR brings the same pattern here.

# Changes

Three new workflows plus one small change to the existing Release workflow, auto-triggering one another:

1. **`bump-version.yml`** (manual dispatch) — choose `patch|minor|major|alpha|beta|rc`; runs `./scripts/version-bump` and opens a release PR from a `release/v<version>` branch using the PR automation bot app token.
2. **`tag-release.yml`** (automatic) — when a `release/v*` PR is merged into `main`, tags the merge commit with `v<version>`. The tag is pushed with the bot app token (not `GITHUB_TOKEN`), so the push **auto-triggers the existing Release workflow**, which builds the artifacts and creates the draft GitHub release.
3. **`release.yml`** (existing) — now also uploads `out/` as a `release-artifacts` workflow run artifact, so the staging deploy can consume exactly what was released.
4. **`deploy-staging.yml`** — triggered by **completion of the Release workflow for a `v*` tag**: it downloads the `release-artifacts` from that run and upgrades the canister, so staging runs *exactly* the released wasm/args — no rebuild. It can also be dispatched manually for any ref, in which case it makes a fresh reproducible docker build (the docker-based staging deploy documented in `HACKING.md`). Deploys via `dfx canister install signer --mode upgrade --upgrade-unchanged --network staging` with a `DFX_DEPLOY_KEY_STAGING` identity, and prints the wasm hash, module hash and `git:commit` metadata for verification.
5. **`prepare-proposal.yml`** (manual dispatch with a release tag) — automates the proposal prep: downloads the release assets (`./scripts/proposal-assets`), rebuilds reproducibly and **fails if the wasm/args hashes don't match the release assets**, generates `PROPOSAL.md`/`ROLLBACK.md` (`./scripts/proposal-template`), and uploads everything as a workflow artifact. Submitting via `./scripts/propose` (neuron required) stays manual.

`HACKING.md` is updated to document the automated flow, keeping the manual steps as a fallback.

# Notes for reviewers

- The end-to-end chain is: dispatch **Version Bump** → merge the release PR → auto-tag → **Release** build → **Deploy to Staging** (release artifacts). Publishing the GitHub release and the production proposal keep their human gates.
- Repo configuration required before the chain is fully functional:
  - `vars.PR_AUTOMATION_BOT_PUBLIC_APP_ID` / `secrets.PR_AUTOMATION_BOT_PUBLIC_PRIVATE_KEY` — same GitHub App used by oisy-wallet; the repo needs to be added to its installation if it isn't already.
  - `secrets.DFX_DEPLOY_KEY_STAGING` — PEM of an identity that is a controller of the staging signer canister (`tdxud-2yaaa-aaaad-aadiq-cai`).
- Action versions are pinned by SHA, matching the pins already used in this repo and in oisy-wallet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)