### PR TITLE
fix(scripts): Cover skipped releases and fix rollback in proposal-template

### DIFF
--- a/scripts/proposal-template
+++ b/scripts/proposal-template
@@ -51,18 +51,20 @@ CHANGE_LOG="$(
 )"
 
 # The rollback target is the version currently deployed, i.e. what we revert to if the
-# upgrade has to be undone.
+# upgrade has to be undone. Prefer a version tag at that commit; other tags (e.g. "prod")
+# may also point there.
 ROLLBACK_REF="$(git rev-parse "$PROD_REF")"
-ROLLBACK_TAG="$(git describe --tags --exact-match "$ROLLBACK_REF" 2>/dev/null || true)"
+ROLLBACK_TAG="$(git tag --points-at "$ROLLBACK_REF" --list 'v*' --sort=-creatordate)"
+ROLLBACK_TAG="${ROLLBACK_TAG%%$'\n'*}"
 ROLLBACK_LABEL="${ROLLBACK_TAG:-$ROLLBACK_REF}"
 ROLLBACK_CHECKOUT="${ROLLBACK_TAG:+tags/$ROLLBACK_TAG}"
 ROLLBACK_CHECKOUT="${ROLLBACK_CHECKOUT:-$ROLLBACK_REF}"
-# Obtain the rollback Wasm hash from the deployed release's published report, if available.
+# Obtain the rollback Wasm hash from the deployed release's published Wasm, if available.
 ROLLBACK_WASM_SHA="(build the rollback Wasm to obtain its hash)"
 if [ -n "$ROLLBACK_TAG" ]; then
   ROLLBACK_TMP="$(mktemp -d)"
-  if gh release download "$ROLLBACK_TAG" --pattern report.txt --dir "$ROLLBACK_TMP" 2>/dev/null; then
-    ROLLBACK_WASM_SHA="$(awk '/signer\.wasm\.gz/ {print $1; exit}' "$ROLLBACK_TMP/report.txt")"
+  if gh release download "$ROLLBACK_TAG" --pattern signer.wasm.gz --dir "$ROLLBACK_TMP" 2>/dev/null; then
+    ROLLBACK_WASM_SHA="$(sha256sum "$ROLLBACK_TMP/signer.wasm.gz" | awk '{print $1}')"
   fi
   rm -rf "$ROLLBACK_TMP"
 fi

--- a/scripts/proposal-template
+++ b/scripts/proposal-template
@@ -27,6 +27,46 @@ export DFX_NETWORK
 # If the currently deployed git ref is not specified, get it from the canister metadata.
 test -n "${PROD_REF:-}" || PROD_REF="$(dfx canister metadata signer git:commit --network "$DFX_NETWORK")"
 
+# The release tags newly included by this upgrade: those reachable from the release
+# candidate but not already deployed (not ancestors of the production ref), oldest
+# first. This matters when releases were skipped, e.g. upgrading production straight
+# from v0.3.0 to v0.4.1 without ever deploying v0.4.0: the change log must then cover
+# every release in between, not just the release candidate.
+RELEASE_TAGS=()
+while IFS= read -r tag; do
+  [ -n "$tag" ] || continue
+  git merge-base --is-ancestor "$tag" "$PROD_REF" && continue # Already deployed.
+  RELEASE_TAGS+=("$tag")
+done < <(git tag --list 'v*' --merged "$RELEASE_CANDIDATE_TAG" --sort=creatordate)
+
+# The change log is the concatenation of the GitHub release notes of every newly
+# included release, oldest first.
+CHANGE_LOG="$(
+  for tag in "${RELEASE_TAGS[@]}"; do
+    printf '### %s\n\n' "$tag"
+    gh release view "$tag" --json body -q .body 2>/dev/null | tr -d "\r" | sed -E 's/^(#+)/###\1/' ||
+      printf '_No GitHub release notes found for %s._' "$tag"
+    printf '\n\n'
+  done
+)"
+
+# The rollback target is the version currently deployed, i.e. what we revert to if the
+# upgrade has to be undone.
+ROLLBACK_REF="$(git rev-parse "$PROD_REF")"
+ROLLBACK_TAG="$(git describe --tags --exact-match "$ROLLBACK_REF" 2>/dev/null || true)"
+ROLLBACK_LABEL="${ROLLBACK_TAG:-$ROLLBACK_REF}"
+ROLLBACK_CHECKOUT="${ROLLBACK_TAG:+tags/$ROLLBACK_TAG}"
+ROLLBACK_CHECKOUT="${ROLLBACK_CHECKOUT:-$ROLLBACK_REF}"
+# Obtain the rollback Wasm hash from the deployed release's published report, if available.
+ROLLBACK_WASM_SHA="(build the rollback Wasm to obtain its hash)"
+if [ -n "$ROLLBACK_TAG" ]; then
+  ROLLBACK_TMP="$(mktemp -d)"
+  if gh release download "$ROLLBACK_TAG" --pattern report.txt --dir "$ROLLBACK_TMP" 2>/dev/null; then
+    ROLLBACK_WASM_SHA="$(awk '/signer\.wasm\.gz/ {print $1; exit}' "$ROLLBACK_TMP/report.txt")"
+  fi
+  rm -rf "$ROLLBACK_TMP"
+fi
+
 RELEASE_GITHUB_URL="$(gh release view "$RELEASE_CANDIDATE_TAG" --json url -q .url)"
 OUTPUT_PROPOSAL="release/PROPOSAL.md"
 OUTPUT_ROLLBACK="release/ROLLBACK.md"
@@ -65,7 +105,7 @@ The chain fusion signer is a canister that makes the internet computer threshold
 
 ## Change Log
 
-$(gh release view "$RELEASE_CANDIDATE_TAG" --json body -q .body | tr -d "\r" | sed -E 's/^#/##/g')
+${CHANGE_LOG}
 
 ## Commit Log
 
@@ -92,16 +132,19 @@ This will generate these files:
 EOF
 
 cat <<EOF >"$OUTPUT_ROLLBACK"
-# Downgrade frontend NNS Dapp canister to commit \`$(git rev-parse "$RELEASE_CANDIDATE_TAG")\`
-Wasm sha256 hash: \`${WASM_SHA}\` (\`${WASM}\`)
+# Roll back Chain Fusion Signer canister to \`${ROLLBACK_LABEL}\`
+Commit: \`${ROLLBACK_REF}\`
+Wasm sha256 hash: \`${ROLLBACK_WASM_SHA}\`
+
+This reverts the Chain Fusion Signer canister to the version that was deployed before ${RELEASE_CANDIDATE_TAG}.
 
 ## Wasm Verification
 
-To build the wasm module yourself and verify its hash, run the following commands from the root of the nns-dapp repo:
+To build the wasm module yourself and verify its hash, run the following commands from the root of the [Chain Fusion Signer repo](https://github.com/dfinity/chain-fusion-signer):
 
 \`\`\`
-git fetch  # to ensure you have the latest changes.
-git checkout "$(git rev-parse "$RELEASE_CANDIDATE_TAG")"
+git fetch --tags # to ensure you have the latest changes.
+git checkout ${ROLLBACK_CHECKOUT}
 ./scripts/docker-build
 \`\`\`
 

--- a/scripts/proposal-template.test.proposal.txt
+++ b/scripts/proposal-template.test.proposal.txt
@@ -9,12 +9,14 @@ The chain fusion signer is a canister that makes the internet computer threshold
 
 ## Change Log
 
-### Features
+### v0.2.8
+
+##### Features
 - Add support for Schnorr signatures. This is useful for cross chain applications wishing to interact with blockchains using Schnorr ed25519.
   - A useful reference may be: http://ethanfast.com/top-crypto.html where curve25519 corresponds to chains that use Schnorr ed25519.
   - We can confirm that Solana transactions can be signed with this API. Other chains should work but have not yet been tested.
 
-### Maintenance
+##### Maintenance
 - Dependencies have been updated.
 - [Pocket-ic canister bindings](https://github.com/dfinity/chain-fusion-signer/tree/v0.2.8/src/signer/canister/tests/it/canister) are now generated automatically, for improved testing.
 - Tooling for creating and verifying NNS proposals has been added.

--- a/scripts/proposal-template.test.rollback.txt
+++ b/scripts/proposal-template.test.rollback.txt
@@ -1,13 +1,16 @@
-# Downgrade frontend NNS Dapp canister to commit `e1c36f468c7b78e851332cc7dae0bfce6bc8f886`
-Wasm sha256 hash: `9d76ee4646df62d1a4bddbdfb4fa78e43166c19a94595ba9e1f5f27b823c8192` (`release/ci/signer.wasm.gz`)
+# Roll back Chain Fusion Signer canister to `v0.2.7`
+Commit: `96ca9850a911396c05825bdbf343c2c57d3d0a5d`
+Wasm sha256 hash: `b3af9a002bd119ea8771bac4db924bb209f0a627a5a4e97d57cf4c0799d74225`
+
+This reverts the Chain Fusion Signer canister to the version that was deployed before v0.2.8.
 
 ## Wasm Verification
 
-To build the wasm module yourself and verify its hash, run the following commands from the root of the nns-dapp repo:
+To build the wasm module yourself and verify its hash, run the following commands from the root of the [Chain Fusion Signer repo](https://github.com/dfinity/chain-fusion-signer):
 
 ```
-git fetch  # to ensure you have the latest changes.
-git checkout "e1c36f468c7b78e851332cc7dae0bfce6bc8f886"
+git fetch --tags # to ensure you have the latest changes.
+git checkout tags/v0.2.7
 ./scripts/docker-build
 ```
 


### PR DESCRIPTION
# Motivation

When preparing a production proposal, [`scripts/proposal-template`](scripts/proposal-template) had two issues that surface whenever production skips a release:

- The **change log** was built from only the release candidate's GitHub notes (`gh release view <tag> --json body`). Upgrading production straight from `v0.3.0` to `v0.4.1` (without ever deploying `v0.4.0`) therefore omitted every change made in `v0.4.0`.
- The generated **`ROLLBACK.md`** pointed at the release candidate itself (the version being installed) instead of the currently deployed version, and still carried copy-paste `nns-dapp` text ("Downgrade frontend NNS Dapp canister", "from the root of the nns-dapp repo").

# Changes

- The change log now concatenates the GitHub release notes of **every** release newly included by the upgrade — those reachable from the release candidate but not yet deployed on the target network (`git tag --merged <candidate>` minus ancestors of the production ref) — oldest first, each under its own `### <tag>` heading.
- `ROLLBACK.md` now targets the **currently deployed** version and references the Chain Fusion Signer repo:
  - The rollback version is resolved from a `v*` tag at the deployed commit (the deployed commit can also carry other tags such as `prod`, so a plain `git describe` is not reliable).
  - The rollback Wasm hash is taken from that release's published `signer.wasm.gz` (older releases such as `v0.2.7` publish no `report.txt`), with a graceful fallback message if the asset is unavailable.
- Updated the golden test fixtures (`scripts/proposal-template.test.{proposal,rollback}.txt`) for the new change-log and rollback format.

# Tests

`./scripts/proposal-template.test` passes (the repo's Shell tests gate), and verified manually against the live setup (production currently on `v0.3.0`, release candidate `v0.4.1`):

- `PROPOSAL.md` change log now contains both `### v0.4.0` and `### v0.4.1` sections (previously only `v0.4.1`).
- `ROLLBACK.md` now reads "Roll back Chain Fusion Signer canister to `v0.3.0`", commit `8cea727`, Wasm hash `103a1a68…` (v0.3.0's published hash, distinct from v0.4.1's `9ebaedd1…`).
- The `v0.2.8`/`v0.2.7` fixture case resolves the rollback to `v0.2.7` (not the colliding `prod` tag) with its real Wasm hash.
- `bash -n` passes; the commit log and hash sections are unchanged.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code) (Opus 4.8)