### PR TITLE
docs(api): Clarify BTC send fee helpers re change output

### DIFF
--- a/src/signer/api/src/methods.rs
+++ b/src/signer/api/src/methods.rs
@@ -25,9 +25,10 @@ impl SignerMethods {
     /// outputs). The value returned here is a **grace-period default** sized for a
     /// 2-input, 2-output transaction; it is intended to give existing callers (who
     /// pre-approve a single cycle amount) a soft landing while they migrate. The
-    /// canister itself deducts the precise amount: [`Self::btc_fee_for_inputs`] for
-    /// `BtcCallerSign`, and [`Self::btc_fee_for_tx`] for `BtcCallerSend`. Callers should
-    /// compute the total with those helpers rather than relying on `fee()`.
+    /// canister itself deducts the amount computed by [`Self::btc_fee_for_inputs`] for
+    /// `BtcCallerSign`, and by [`Self::btc_fee_for_tx`] for `BtcCallerSend` (with
+    /// `n_outputs` including a potential change output). Callers should compute the total
+    /// with those helpers rather than relying on `fee()`.
     #[must_use]
     #[allow(clippy::match_same_arms)]
     pub fn fee(&self) -> u128 {

--- a/src/signer/api/src/methods.rs
+++ b/src/signer/api/src/methods.rs
@@ -110,7 +110,8 @@ impl SignerMethods {
     }
 
     /// Total fee for a BTC send call that processes `n_inputs` inputs and `n_outputs`
-    /// outputs.
+    /// outputs (including a potential change output; `btc_caller_send` charges
+    /// `requested_outputs + 1`).
     ///
     /// Inputs drive the per-signature (`sign_with_ecdsa`) cost; outputs drive the
     /// byte-based `bitcoin_send_transaction` cost. Pricing both prevents a caller from


### PR DESCRIPTION
# Motivation

Follow-up to https://github.com/dfinity/chain-fusion-signer/pull/528, addressing two Copilot review comments left on that PR after it merged. The api-crate fee docs didn't mention the change output: `btc_caller_send` prices `requested_outputs + 1` (the extra output covers a possible change output), so a caller sizing their payment from the helpers with only their requested output count under-attaches by one output's fee (1e9 cycles) and the deduction fails. Documentation only — no behavior change.

# Changes

- `fee()` doc: replace "deducts the precise amount" with "deducts the amount computed by `btc_fee_for_tx` (with `n_outputs` including a potential change output)".
- `btc_fee_for_tx` doc: note that `n_outputs` should include a potential change output and that `btc_caller_send` charges `requested_outputs + 1`.

# Tests

- `cargo test -p ic-chain-fusion-signer-api`, `cargo fmt --check` pass. Doc-only; no logic change.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code) — Claude Opus 4.8 (1M context)
