### PR TITLE
feat: add BTC broadcast endpoint for externally-built transactions

### DIFF
--- a/src/signer/api/src/methods.rs
+++ b/src/signer/api/src/methods.rs
@@ -9,6 +9,7 @@ pub enum SignerMethods {
     BtcCallerAddress,
     BtcCallerBalance,
     BtcCallerSend,
+    BtcCallerSendRawTransaction,
     BtcCallerSign,
     SchnorrPublicKey,
     SchnorrSign,
@@ -40,6 +41,22 @@ impl SignerMethods {
             // btc_base_fee() + 2 * btc_per_input_fee() + 2 * btc_per_output_fee()
             //   = 95 B + 2 * 37 B + 2 * 1 B = 171 B
             SignerMethods::BtcCallerSend => 171_000_000_000,
+            // Flat fee for broadcasting an externally-built, already-signed raw transaction.
+            //
+            // Unlike `BtcCallerSend`, this method performs NO t-ECDSA signing, so it is NOT
+            // priced per input. Its only cost is the `bitcoin_send_transaction` outcall, whose
+            // mainnet cost is `5e9 + 20e6 * transaction_bytes`. A raw transaction can be large
+            // (the protocol caps it around 100 KB), giving a worst-case outcall cost of roughly
+            // `5e9 + 20e6 * 100_000 ≈ 2e12` cycles for a pathological payload, but a few hundred
+            // bytes for a normal one.
+            //
+            // The endpoint is a public relay, so the threat model is DoS / cycle-drain rather
+            // than UTXO theft (a valid signature is still required for the Bitcoin network to
+            // accept the tx). A flat 100 B cycles sits in the same magnitude family as the other
+            // BTC methods, comfortably exceeds the broadcast cost of any realistic transaction,
+            // and makes spamming the relay to drain canister cycles uneconomical. It is a flat
+            // fee because there is no per-input/per-signature work to meter here.
+            SignerMethods::BtcCallerSendRawTransaction => 100_000_000_000,
             // Grace-period default sized for a 2-input transaction:
             // btc_base_fee() + 2 * btc_per_input_fee() = 74 B + 2 * 37 B = 148 B
             SignerMethods::BtcCallerSign => 148_000_000_000,
@@ -125,9 +142,22 @@ impl SignerMethods {
 
 #[cfg(test)]
 mod tests {
-    use super::SignerMethods::{BtcCallerSend, BtcCallerSign};
+    use super::SignerMethods::{BtcCallerSend, BtcCallerSendRawTransaction, BtcCallerSign};
 
     const B: u128 = 1_000_000_000;
+
+    #[test]
+    fn send_raw_transaction_charges_a_flat_fee() {
+        // The raw-broadcast relay does no t-ECDSA signing, so its fee is a single flat value and
+        // does not scale with inputs or outputs.
+        assert_eq!(BtcCallerSendRawTransaction.fee(), 100 * B);
+        assert_eq!(BtcCallerSendRawTransaction.btc_per_input_fee(), 0);
+        assert_eq!(BtcCallerSendRawTransaction.btc_per_output_fee(), 0);
+        assert_eq!(
+            BtcCallerSendRawTransaction.btc_fee_for_tx(10, 10),
+            BtcCallerSendRawTransaction.fee(),
+        );
+    }
 
     #[test]
     fn send_prices_each_output() {

--- a/src/signer/canister/signer.did
+++ b/src/signer/canister/signer.did
@@ -216,24 +216,25 @@ type RejectionCode = variant {
 type Result = variant { Ok : GetAddressResponse; Err : GetAddressError };
 type Result_1 = variant { Ok : GetBalanceResponse; Err : GetAddressError };
 type Result_10 = variant {
+  Ok : record { EcdsaPublicKeyResult };
+  Err : EthAddressError;
+};
+type Result_11 = variant {
   Ok : record { SignWithEcdsaResult };
   Err : EthAddressError;
 };
 type Result_2 = variant { Ok : SendBtcResponse; Err : SendBtcError };
-type Result_3 = variant { Ok : SignBtcResponse; Err : SendBtcError };
-type Result_4 = variant { Ok : EthAddressResponse; Err : EthAddressError };
-type Result_5 = variant { Ok : EthPersonalSignResponse; Err : EthAddressError };
-type Result_6 = variant { Ok : EthSignPrehashResponse; Err : EthAddressError };
-type Result_7 = variant {
-  Ok : record { EcdsaPublicKeyResult };
-  Err : EthAddressError;
-};
+type Result_3 = variant { Ok; Err : SendBtcError };
+type Result_4 = variant { Ok : SignBtcResponse; Err : SendBtcError };
+type Result_5 = variant { Ok : EthAddressResponse; Err : EthAddressError };
+type Result_6 = variant { Ok : EthPersonalSignResponse; Err : EthAddressError };
+type Result_7 = variant { Ok : EthSignPrehashResponse; Err : EthAddressError };
 type Result_8 = variant {
-  Ok : record { SignWithEcdsaResult };
+  Ok : record { EcdsaPublicKeyResult };
   Err : EthAddressError;
 };
 type Result_9 = variant {
-  Ok : record { EcdsaPublicKeyResult };
+  Ok : record { SignWithEcdsaResult };
   Err : EthAddressError;
 };
 // # Schnorr Algorithm.
@@ -384,6 +385,33 @@ service : (Arg) -> {
   // # Panics
   // - If the caller is the anonymous user.
   btc_caller_send : (SendBtcRequest, opt PaymentType) -> (Result_2);
+  // Broadcasts an already-signed, externally-built BTC transaction (raw bytes).
+  // 
+  // Unlike [`btc_caller_send`], this endpoint does not build, sign or finalize anything: it
+  // relays the caller-provided raw transaction bytes straight to the Bitcoin network. It exists
+  // so that a client (e.g. a wallet that finalized a PSBT itself) can broadcast a transaction the
+  // signer never constructed — for example WalletConnect `signPsbt` with `broadcast: true`.
+  // 
+  // # Details
+  // - Charges a FLAT fee via `PAYMENT_GUARD.deduct(..)` BEFORE the outcall (see
+  // [`SignerMethods::BtcCallerSendRawTransaction`]). No t-ECDSA signing happens here, so the fee
+  // is not priced per input/output.
+  // - Sends the transaction with `bitcoin_api::send_transaction(..)`.
+  // - Costs: See [Bitcoin API fees and pricing](https://internetcomputer.org/docs/current/references/bitcoin-how-it-works#api-fees-and-pricing)
+  // 
+  // # Security
+  // This is a public relay. The threat model is DoS / cycle-drain, not theft: the Bitcoin network
+  // only accepts a transaction that already carries valid signatures, so a caller cannot spend
+  // UTXOs they do not control. The flat payment-guard fee, enforced before the outcall, is the
+  // mitigation against cheap amplification. The raw bytes are passed through verbatim — they are
+  // never deserialized here — so invalid or garbage bytes are rejected by the Bitcoin canister and
+  // surfaced as `SendBtcError::InternalError`; this endpoint never panics on them.
+  // 
+  // # Panics
+  // - If the caller is the anonymous user.
+  btc_caller_send_raw_transaction : (Network, blob, opt PaymentType) -> (
+      Result_3,
+    );
   // Creates and signs a BTC transaction from the caller's address without broadcasting it.
   // 
   // # Details
@@ -397,7 +425,7 @@ service : (Arg) -> {
   // 
   // # Panics
   // - If the caller is the anonymous user.
-  btc_caller_sign : (SendBtcRequest, opt PaymentType) -> (Result_3);
+  btc_caller_sign : (SendBtcRequest, opt PaymentType) -> (Result_4);
   // Show the canister configuration.
   config : () -> (Config) query;
   // Returns the Ethereum address of a specified user.
@@ -412,7 +440,7 @@ service : (Arg) -> {
   // 
   // # Panics
   // - If the caller is the anonymous user.
-  eth_address : (EthAddressRequest, opt PaymentType) -> (Result_4);
+  eth_address : (EthAddressRequest, opt PaymentType) -> (Result_5);
   // Returns the Ethereum address of the caller.
   // 
   // # Details
@@ -423,7 +451,7 @@ service : (Arg) -> {
   // 
   // # Panics
   // - If the caller is the anonymous user.
-  eth_address_of_caller : (opt PaymentType) -> (Result_4);
+  eth_address_of_caller : (opt PaymentType) -> (Result_5);
   // Computes an Ethereum signature for a hex-encoded message according to [EIP-191](https://eips.ethereum.org/EIPS/eip-191).
   // 
   // # Details
@@ -438,7 +466,7 @@ service : (Arg) -> {
   // 
   // # Panics
   // - If the caller is the anonymous user.
-  eth_personal_sign : (EthPersonalSignRequest, opt PaymentType) -> (Result_5);
+  eth_personal_sign : (EthPersonalSignRequest, opt PaymentType) -> (Result_6);
   // Computes an Ethereum signature for a precomputed hash.
   // 
   // # Details
@@ -452,7 +480,7 @@ service : (Arg) -> {
   // 
   // # Panics
   // - If the caller is the anonymous user.
-  eth_sign_prehash : (EthSignPrehashRequest, opt PaymentType) -> (Result_6);
+  eth_sign_prehash : (EthSignPrehashRequest, opt PaymentType) -> (Result_7);
   // Computes an Ethereum signature for an [EIP-1559](https://eips.ethereum.org/EIPS/eip-1559) transaction.
   // 
   // # Details
@@ -468,7 +496,7 @@ service : (Arg) -> {
   // # Panics
   // - If the caller is the anonymous user.
   eth_sign_transaction : (EthSignTransactionRequest, opt PaymentType) -> (
-      Result_6,
+      Result_7,
     );
   // Returns the generic ECDSA public key of the caller.
   // 
@@ -485,7 +513,7 @@ service : (Arg) -> {
   // # Panics
   // - If the caller is the anonymous user.
   generic_caller_ecdsa_public_key : (EcdsaPublicKeyArgs, opt PaymentType) -> (
-      Result_7,
+      Result_8,
     );
   // Signs a message using the caller's ECDSA key.
   // 
@@ -501,7 +529,7 @@ service : (Arg) -> {
   // 
   // # Panics
   // - If the caller is the anonymous user.
-  generic_sign_with_ecdsa : (opt PaymentType, SignWithEcdsaArgs) -> (Result_8);
+  generic_sign_with_ecdsa : (opt PaymentType, SignWithEcdsaArgs) -> (Result_9);
   // API method to get cycle balance and burn rate.
   get_canister_status : () -> (CanisterStatusResultV2);
   // Processes external HTTP requests.
@@ -538,7 +566,7 @@ service : (Arg) -> {
   // 
   // # Panics
   // - If the caller is the anonymous user.
-  schnorr_public_key : (SchnorrPublicKeyArgs, opt PaymentType) -> (Result_9);
+  schnorr_public_key : (SchnorrPublicKeyArgs, opt PaymentType) -> (Result_10);
   // Signs a message using the caller's Schnorr key.
   // 
   // Note: This is an exact dual of the canister [`sign_with_schnorr`](https://internetcomputer.org/docs/current/references/ic-interface-spec/#ic-sign_with_schnorr) method.  The argument and response types are also the same.
@@ -571,5 +599,5 @@ service : (Arg) -> {
   // 
   // # Panics
   // - If the caller is the anonymous user.
-  schnorr_sign : (SignWithSchnorrArgs, opt PaymentType) -> (Result_10);
+  schnorr_sign : (SignWithSchnorrArgs, opt PaymentType) -> (Result_11);
 }

--- a/src/signer/canister/src/lib.rs
+++ b/src/signer/canister/src/lib.rs
@@ -1,5 +1,6 @@
 use candid::Principal;
 use ic_cdk::{api::msg_caller, export_candid, init, post_upgrade, query, update};
+use ic_cdk_bitcoin_canister::Network;
 use ic_cdk_management_canister::{
     EcdsaPublicKeyArgs, EcdsaPublicKeyResult, SchnorrPublicKeyArgs, SchnorrPublicKeyResult,
     SignWithEcdsaArgs, SignWithEcdsaResult, SignWithSchnorrArgs, SignWithSchnorrResult,
@@ -619,6 +620,48 @@ pub async fn btc_caller_send(
             })
         }
     }
+}
+
+/// Broadcasts an already-signed, externally-built BTC transaction (raw bytes).
+///
+/// Unlike [`btc_caller_send`], this endpoint does not build, sign or finalize anything: it
+/// relays the caller-provided raw transaction bytes straight to the Bitcoin network. It exists
+/// so that a client (e.g. a wallet that finalized a PSBT itself) can broadcast a transaction the
+/// signer never constructed — for example `WalletConnect` `signPsbt` with `broadcast: true`.
+///
+/// # Details
+/// - Charges a FLAT fee via `PAYMENT_GUARD.deduct(..)` BEFORE the outcall (see
+///   [`SignerMethods::BtcCallerSendRawTransaction`]). No t-ECDSA signing happens here, so the fee
+///   is not priced per input/output.
+/// - Sends the transaction with `bitcoin_api::send_transaction(..)`.
+///   - Costs: See [Bitcoin API fees and pricing](https://internetcomputer.org/docs/current/references/bitcoin-how-it-works#api-fees-and-pricing)
+///
+/// # Security
+/// This is a public relay. The threat model is `DoS` / cycle-drain, not theft: the Bitcoin network
+/// only accepts a transaction that already carries valid signatures, so a caller cannot spend
+/// UTXOs they do not control. The flat payment-guard fee, enforced before the outcall, is the
+/// mitigation against cheap amplification. The raw bytes are passed through verbatim — they are
+/// never deserialized here — so invalid or garbage bytes are rejected by the Bitcoin canister and
+/// surfaced as `SendBtcError::InternalError`; this endpoint never panics on them.
+///
+/// # Panics
+/// - If the caller is the anonymous user.
+#[update(guard = "caller_is_not_anonymous")]
+pub async fn btc_caller_send_raw_transaction(
+    network: Network,
+    transaction: Vec<u8>,
+    payment: Option<PaymentType>,
+) -> Result<(), SendBtcError> {
+    PAYMENT_GUARD
+        .deduct(
+            payment.unwrap_or(PaymentType::AttachedCycles),
+            SignerMethods::BtcCallerSendRawTransaction.fee(),
+        )
+        .await?;
+
+    bitcoin_api::send_transaction(network, transaction)
+        .await
+        .map_err(|msg| SendBtcError::InternalError { msg })
 }
 
 // /////////////////////

--- a/src/signer/canister/tests/it/bitcoin.rs
+++ b/src/signer/canister/tests/it/bitcoin.rs
@@ -297,3 +297,94 @@ mod caller_sign {
         assert!(hex::decode(&response.signed_transaction_hex).is_ok());
     }
 }
+
+mod caller_send_raw {
+    use super::*;
+
+    /// A standard `btc_caller_send_raw_transaction()` call, approving exactly the flat fee.
+    fn paid_caller_send_raw(
+        test_env: &TestSetup,
+        caller: Principal,
+        network: Network,
+        transaction: &[u8],
+    ) -> Result<Result<(), SendBtcError>, String> {
+        let payment_type = PaymentType::CallerPaysIcrc2Cycles;
+        let payment_recipient = cycles_ledger::Account {
+            owner: test_env.signer.canister_id(),
+            subaccount: None,
+        };
+        let amount: u128 = SignerMethods::BtcCallerSendRawTransaction.fee() + LEDGER_FEE;
+        test_env
+            .ledger
+            .icrc2_approve(caller, &ApproveArgs::new(payment_recipient, amount.into()))
+            .expect("Failed to call ledger canister")
+            .expect("Failed to approve payment");
+
+        test_env.signer.btc_caller_send_raw_transaction(
+            caller,
+            &network,
+            &serde_bytes::ByteBuf::from(transaction.to_vec()),
+            &Some(payment_type),
+        )
+    }
+
+    #[test]
+    fn test_anonymous_cannot_send_raw_transaction() {
+        let test_env = TestSetup::default();
+
+        let response = test_env.signer.btc_caller_send_raw_transaction(
+            Principal::anonymous(),
+            &Network::Regtest,
+            &serde_bytes::ByteBuf::from(vec![0x01, 0x02, 0x03]),
+            &Some(PaymentType::CallerPaysIcrc2Cycles),
+        );
+
+        assert!(response.is_err());
+        assert_eq!(
+            response.unwrap_err(),
+            "Update call error. RejectionCode: CanisterReject, Error: Update call error. RejectionCode: CanisterReject, Error: Anonymous caller not authorized.".to_string()
+        );
+    }
+
+    #[test]
+    fn test_send_raw_without_payment_fails_with_payment_error() {
+        let test_env = TestSetup::default();
+
+        // No icrc2_approve: the payment guard must reject before any Bitcoin outcall.
+        let response = test_env
+            .signer
+            .btc_caller_send_raw_transaction(
+                test_env.user,
+                &Network::Regtest,
+                &serde_bytes::ByteBuf::from(vec![0x01, 0x02, 0x03]),
+                &Some(PaymentType::CallerPaysIcrc2Cycles),
+            )
+            .expect("Failed to call btc_caller_send_raw_transaction");
+
+        assert!(
+            matches!(response, Err(SendBtcError::PaymentError(_))),
+            "expected a PaymentError, got {response:?}"
+        );
+    }
+
+    #[test]
+    fn test_send_raw_garbage_bytes_is_rejected_gracefully() {
+        let test_env = TestSetup::default();
+
+        // The fee is charged up front (the payment guard runs before the outcall); the Bitcoin
+        // canister then rejects the malformed transaction. The endpoint must surface this as a
+        // graceful `InternalError` rather than trapping/panicking on the invalid bytes.
+        let response = paid_caller_send_raw(
+            &test_env,
+            test_env.user,
+            Network::Regtest,
+            &[0xde, 0xad, 0xbe, 0xef],
+        )
+        .expect("Call to btc_caller_send_raw_transaction trapped unexpectedly");
+
+        assert!(
+            matches!(response, Err(SendBtcError::InternalError { .. })),
+            "expected an InternalError from the Bitcoin canister, got {response:?}"
+        );
+    }
+}

--- a/src/signer/canister/tests/it/canister/signer.rs
+++ b/src/signer/canister/tests/it/canister/signer.rs
@@ -228,12 +228,13 @@ pub(crate) enum SendBtcError {
     PaymentError(PaymentError),
 }
 pub(crate) type Result2 = std::result::Result<SendBtcResponse, SendBtcError>;
+pub(crate) type Result3 = std::result::Result<(), SendBtcError>;
 #[derive(CandidType, Deserialize, Debug, Eq, PartialEq, Clone)]
 pub(crate) struct SignBtcResponse {
     pub(crate) txid: String,
     pub(crate) signed_transaction_hex: String,
 }
-pub(crate) type Result3 = std::result::Result<SignBtcResponse, SendBtcError>;
+pub(crate) type Result4 = std::result::Result<SignBtcResponse, SendBtcError>;
 #[derive(CandidType, Deserialize, Debug, Eq, PartialEq, Clone)]
 pub(crate) struct Config {
     pub(crate) ecdsa_key_name: String,
@@ -258,7 +259,7 @@ pub(crate) enum EthAddressError {
     /// Payment failed.
     PaymentError(PaymentError),
 }
-pub(crate) type Result4 = std::result::Result<EthAddressResponse, EthAddressError>;
+pub(crate) type Result5 = std::result::Result<EthAddressResponse, EthAddressError>;
 #[derive(CandidType, Deserialize, Debug, Eq, PartialEq, Clone)]
 pub(crate) struct EthPersonalSignRequest {
     pub(crate) message: String,
@@ -267,7 +268,7 @@ pub(crate) struct EthPersonalSignRequest {
 pub(crate) struct EthPersonalSignResponse {
     pub(crate) signature: String,
 }
-pub(crate) type Result5 = std::result::Result<EthPersonalSignResponse, EthAddressError>;
+pub(crate) type Result6 = std::result::Result<EthPersonalSignResponse, EthAddressError>;
 #[derive(CandidType, Deserialize, Debug, Eq, PartialEq, Clone)]
 pub(crate) struct EthSignPrehashRequest {
     pub(crate) hash: String,
@@ -276,7 +277,7 @@ pub(crate) struct EthSignPrehashRequest {
 pub(crate) struct EthSignPrehashResponse {
     pub(crate) signature: String,
 }
-pub(crate) type Result6 = std::result::Result<EthSignPrehashResponse, EthAddressError>;
+pub(crate) type Result7 = std::result::Result<EthSignPrehashResponse, EthAddressError>;
 #[derive(CandidType, Deserialize, Debug, Eq, PartialEq, Clone)]
 pub(crate) struct EthSignTransactionRequest {
     pub(crate) to: String,
@@ -327,7 +328,7 @@ pub(crate) struct EcdsaPublicKeyResult {
     /// Can be used to deterministically derive child keys of the [`public_key`](Self::public_key).
     pub(crate) chain_code: serde_bytes::ByteBuf,
 }
-pub(crate) type Result7 = std::result::Result<(EcdsaPublicKeyResult,), EthAddressError>;
+pub(crate) type Result8 = std::result::Result<(EcdsaPublicKeyResult,), EthAddressError>;
 /// # Sign With ECDSA Args.
 ///
 /// Argument type of [`sign_with_ecdsa`](https://internetcomputer.org/docs/current/references/ic-interface-spec/#ic-sign_with_ecdsa).
@@ -348,7 +349,7 @@ pub(crate) struct SignWithEcdsaResult {
     /// Encoded as the concatenation of the SEC1 encodings of the two values `r` and `s`.
     pub(crate) signature: serde_bytes::ByteBuf,
 }
-pub(crate) type Result8 = std::result::Result<(SignWithEcdsaResult,), EthAddressError>;
+pub(crate) type Result9 = std::result::Result<(SignWithEcdsaResult,), EthAddressError>;
 /// # Canister Status Type
 ///
 /// Status of a canister.
@@ -439,7 +440,7 @@ pub(crate) struct SchnorrPublicKeyArgs {
     /// A vector of variable length byte strings.
     pub(crate) derivation_path: Vec<serde_bytes::ByteBuf>,
 }
-pub(crate) type Result9 = std::result::Result<(EcdsaPublicKeyResult,), EthAddressError>;
+pub(crate) type Result10 = std::result::Result<(EcdsaPublicKeyResult,), EthAddressError>;
 /// # Bip341 variant of Schnorr Aux.
 #[derive(CandidType, Deserialize, Debug, Eq, PartialEq, Clone)]
 pub(crate) struct Bip341 {
@@ -466,7 +467,7 @@ pub(crate) struct SignWithSchnorrArgs {
     /// Message to be signed.
     pub(crate) message: serde_bytes::ByteBuf,
 }
-pub(crate) type Result10 = std::result::Result<(SignWithEcdsaResult,), EthAddressError>;
+pub(crate) type Result11 = std::result::Result<(SignWithEcdsaResult,), EthAddressError>;
 
 pub struct SignerPic {
     pub pic: Arc<PocketIc>,
@@ -518,12 +519,25 @@ impl SignerPic {
     ) -> Result<Result2, String> {
         self.update(caller, "btc_caller_send", (arg0, arg1))
     }
+    pub fn btc_caller_send_raw_transaction(
+        &self,
+        caller: Principal,
+        arg0: &Network,
+        arg1: &serde_bytes::ByteBuf,
+        arg2: &Option<PaymentType>,
+    ) -> Result<Result3, String> {
+        self.update(
+            caller,
+            "btc_caller_send_raw_transaction",
+            (arg0, arg1, arg2),
+        )
+    }
     pub fn btc_caller_sign(
         &self,
         caller: Principal,
         arg0: &SendBtcRequest,
         arg1: &Option<PaymentType>,
-    ) -> Result<Result3, String> {
+    ) -> Result<Result4, String> {
         self.update(caller, "btc_caller_sign", (arg0, arg1))
     }
     pub fn config(&self, caller: Principal) -> Result<Config, String> {
@@ -534,14 +548,14 @@ impl SignerPic {
         caller: Principal,
         arg0: &EthAddressRequest,
         arg1: &Option<PaymentType>,
-    ) -> Result<Result4, String> {
+    ) -> Result<Result5, String> {
         self.update(caller, "eth_address", (arg0, arg1))
     }
     pub fn eth_address_of_caller(
         &self,
         caller: Principal,
         arg0: &Option<PaymentType>,
-    ) -> Result<Result4, String> {
+    ) -> Result<Result5, String> {
         self.update(caller, "eth_address_of_caller", (arg0,))
     }
     pub fn eth_personal_sign(
@@ -549,7 +563,7 @@ impl SignerPic {
         caller: Principal,
         arg0: &EthPersonalSignRequest,
         arg1: &Option<PaymentType>,
-    ) -> Result<Result5, String> {
+    ) -> Result<Result6, String> {
         self.update(caller, "eth_personal_sign", (arg0, arg1))
     }
     pub fn eth_sign_prehash(
@@ -557,7 +571,7 @@ impl SignerPic {
         caller: Principal,
         arg0: &EthSignPrehashRequest,
         arg1: &Option<PaymentType>,
-    ) -> Result<Result6, String> {
+    ) -> Result<Result7, String> {
         self.update(caller, "eth_sign_prehash", (arg0, arg1))
     }
     pub fn eth_sign_transaction(
@@ -565,7 +579,7 @@ impl SignerPic {
         caller: Principal,
         arg0: &EthSignTransactionRequest,
         arg1: &Option<PaymentType>,
-    ) -> Result<Result6, String> {
+    ) -> Result<Result7, String> {
         self.update(caller, "eth_sign_transaction", (arg0, arg1))
     }
     pub fn generic_caller_ecdsa_public_key(
@@ -573,7 +587,7 @@ impl SignerPic {
         caller: Principal,
         arg0: &EcdsaPublicKeyArgs,
         arg1: &Option<PaymentType>,
-    ) -> Result<Result7, String> {
+    ) -> Result<Result8, String> {
         self.update(caller, "generic_caller_ecdsa_public_key", (arg0, arg1))
     }
     pub fn generic_sign_with_ecdsa(
@@ -581,7 +595,7 @@ impl SignerPic {
         caller: Principal,
         arg0: &Option<PaymentType>,
         arg1: &SignWithEcdsaArgs,
-    ) -> Result<Result8, String> {
+    ) -> Result<Result9, String> {
         self.update(caller, "generic_sign_with_ecdsa", (arg0, arg1))
     }
     pub fn get_canister_status(&self, caller: Principal) -> Result<CanisterStatusResultV2, String> {
@@ -599,7 +613,7 @@ impl SignerPic {
         caller: Principal,
         arg0: &SchnorrPublicKeyArgs,
         arg1: &Option<PaymentType>,
-    ) -> Result<Result9, String> {
+    ) -> Result<Result10, String> {
         self.update(caller, "schnorr_public_key", (arg0, arg1))
     }
     pub fn schnorr_sign(
@@ -607,7 +621,7 @@ impl SignerPic {
         caller: Principal,
         arg0: &SignWithSchnorrArgs,
         arg1: &Option<PaymentType>,
-    ) -> Result<Result10, String> {
+    ) -> Result<Result11, String> {
         self.update(caller, "schnorr_sign", (arg0, arg1))
     }
 }


### PR DESCRIPTION
> [!CAUTION]
> **DO NOT MERGE THIS PR**
> We for now don't support broadcast request for BTC via WalletConnect. It can break atomicity and might require us to track a status on our side to act later in case a connection is lost after broadcasting a transaction.

# Motivation

`btc_caller_send` only broadcasts a transaction that the signer itself builds and signs. There is no way to relay raw bytes that a client finalized on its own — e.g. an OISY frontend that finalized a PSBT and needs the signer to broadcast it (WalletConnect `signPsbt` with `broadcast: true`).

This adds a thin public broadcast endpoint for already-signed, externally-built transactions.

# Changes

- New `#[update]` endpoint `btc_caller_send_raw_transaction(network: Network, transaction: Vec<u8>, payment: Option<PaymentType>) -> Result<(), SendBtcError>`.
  - Charges a **flat** payment-guard fee via a new `SignerMethods::BtcCallerSendRawTransaction` variant (`100_000_000_000` cycles), enforced **before** the outcall.
  - Calls `bitcoin_api::send_transaction(network, transaction)` directly — no PSBT parsing, no signing, no finalization.
  - The raw bytes are never deserialized in the canister; malformed bytes are rejected by the Bitcoin canister and surfaced as `SendBtcError::InternalError` (the endpoint never traps on garbage input).
- Flat fee (not the per-input/output `btc_fee_for_tx`) because no t-ECDSA work happens here; the only cost is the broadcast outcall. Rationale is documented inline on the `fee()` arm.
- Regenerated candid (`signer.did`) and the PocketIC test bindings.

# Tests

- Unit test in `methods.rs`: the new variant charges a flat fee and does not scale with inputs/outputs.
- Integration tests (`tests/it/bitcoin.rs`, `caller_send_raw`):
  - anonymous caller is rejected;
  - missing payment is rejected with `PaymentError` before any Bitcoin outcall;
  - with the fee paid, garbage bytes are rejected gracefully as `InternalError` (no trap).
- Ran `cargo +nightly fmt --check`, `./scripts/lint-rs`, `./scripts/did.sh`, the api unit tests, and the targeted signer integration tests (`./scripts/test.signer.sh caller_send_raw`) — all green. Full heavy suite not run.

> **Security review required (release gate):** this is a new **public relay** endpoint. The threat model is DoS / cycle-drain rather than UTXO theft (the Bitcoin network still requires valid signatures, so a caller cannot spend UTXOs they do not control). The flat payment-guard fee, enforced before the outcall, is the mitigation against cheap amplification. Please review whether the flat fee magnitude is appropriate before release.
