### PR TITLE
docs(ci): Document the release bot credentials prerequisite

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -91,6 +91,7 @@ dfx canister install signer --wasm out/signer.wasm.gz \
 ```
 
 **CHECK** (prefix queries with `DFX_WARNING=-mainnet_plaintext_identity` if a plaintext-identity confirmation appears):
+
 - `dfx canister info signer --network staging` → **module hash equals the release wasm hash** (step 3); `git:tags` = `v<version>`, `git:commit` = the release commit.
 - `dfx canister call signer config --network staging` → still `ecdsa_key_name = "test_key_1"` (**not** `key_1`).
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -93,6 +93,8 @@ If you are not a controller, you may request a canister upgrade via Orbit; conta
 
 ## 4. Upgrade production (NNS proposal)
 
+> ⚠️ **The [Prepare Production Proposal](.github/workflows/prepare-proposal.yml) workflow is currently broken** — its "Build reproducibly" step runs `git log | head -n1` under `set -o pipefail`, so `git log` gets SIGPIPE and the step fails with exit code 141 (fix: use `git log -1 --format=%H`). Until that is fixed, prepare the proposal with the **by-hand scripts** below; they do exactly the same work locally and are the path verified for `v0.5.0`.
+
 - Ensure the GitHub release for the tag has been **published** (step 2).
 - Trigger the [Prepare Production Proposal](.github/workflows/prepare-proposal.yml) workflow with the release tag. It downloads the release assets, runs a reproducible docker build, verifies the Wasm and argument hashes match the release, generates `release/PROPOSAL.md` and `release/ROLLBACK.md`, and uploads everything as the `proposal-$TAG` workflow artifact.
 - On your machine (see prerequisites below):
@@ -114,6 +116,31 @@ If you are not a controller, you may request a canister upgrade via Orbit; conta
 
 ### Running the proposal scripts by hand
 
-The proposal scripts can also be run directly instead of via the Prepare Production Proposal workflow: `./scripts/proposal-assets -t v<version>`, then verify with a local `./scripts/docker-build`, then `./scripts/proposal-template -t v<version>`, then `./scripts/propose`. The manual fallback additionally requires **Docker** and **bash >= 5** (see the tooling notes linked above), since `./scripts/docker-build` needs both.
+Run these from an up-to-date `main` checkout (you pick up the latest tooling fixes; the scripts target the release via `-t v<version>` and need not run from the release commit). The first three steps are a **safe dry run** — they download, build, and template only; nothing touches the HSM or gets submitted, so you can review everything in advance. They additionally require **Docker** and **bash >= 5** (see the tooling notes linked above).
 
-> Note: run the proposal scripts from an up-to-date `main` checkout rather than the release tag, so you pick up the latest tooling fixes (the scripts target the release via `-t v<version>` and do not need to be run from the release commit).
+```
+# 1. Download the published release assets into release/ci/ (prints their sha256sums).
+./scripts/proposal-assets -t v<version>
+
+# 2. Reproduce the build locally and verify it is bit-for-bit identical to the release.
+#    out/signer.wasm.gz must equal the `out/signer.wasm.gz` hash in release/ci/report.txt;
+#    out/signer.args.{did,bin} must equal the matching release/ci files.
+./scripts/docker-build
+sha256sum out/signer.wasm.gz   # compare against release/ci/report.txt
+
+# 3. Generate the proposal text and review it.
+./scripts/proposal-template -t v<version>
+#    -> release/PROPOSAL.md  (upgrade to v<version>: target canister, wasm + arg hashes, changelog)
+#    -> release/ROLLBACK.md  (revert to the previous version)
+```
+
+Sanity-check `release/PROPOSAL.md`: the wasm hash matches step 2, the **Candid/binary arg hashes are the production args** (`ecdsa_key_name = "key_1"`, not `test_key_1`), and `release/ROLLBACK.md` points at the version currently on production.
+
+Then submit (HSM-gated — see prerequisites above):
+
+```
+# 4. Builds the ic-admin command, prints it for review, then signs with the HSM and submits.
+./scripts/propose
+```
+
+> Note: `out/` and `release/ci/` are build outputs left in the working tree by the dry run — harmless, git-ignored, and overwritten on the next run.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -6,6 +6,8 @@ For a throwaway **test release**, just push any tag and the [Release](.github/wo
 
 ## 1. Cut the release
 
+> **Prerequisite for the automated path.** Both the [Version Bump and Release Branch Creation](.github/workflows/bump-version.yml) and [Tag on Merge from Release Branch](.github/workflows/tag-release.yml) workflows authenticate as a GitHub App, using the `PR_AUTOMATION_BOT_PUBLIC_APP_ID` repository (or org) variable and the `PR_AUTOMATION_BOT_PUBLIC_PRIVATE_KEY` secret. If these are not provisioned, both workflows fail immediately at the "Create GitHub App Token" step (`private-key input must be set to a non-empty string`). Until they are set up, use the **By hand** steps below instead.
+
 - Trigger the [Version Bump and Release Branch Creation](.github/workflows/bump-version.yml) workflow from the GitHub Actions tab, choosing the bump type (`patch | minor | major | alpha | beta | rc`).
   - This runs `./scripts/version-bump`, which bumps `[workspace.package].version` in the root `Cargo.toml` and regenerates `Cargo.lock`, then opens a release PR from a `release/v*` branch.
 - Review and merge the release PR.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,146 +1,153 @@
-# Release checklist
+# Release runbook
 
-A concise, end-to-end checklist for cutting a new release, deploying to `staging`, and upgrading production via an NNS proposal.
+An end-to-end, step-by-step guide for cutting a release, deploying it to `staging`, and upgrading production via an NNS proposal.
 
-For a throwaway **test release**, just push any tag and the [Release](.github/workflows/release.yml) workflow builds the artifacts and creates a release for that tag. The sections below describe a full **production release**.
+It is written as a **by-hand runbook**, because the CI automation is not fully provisioned yet (see [Automation](#automation-once-secrets-are-provisioned) at the end). Follow the numbered steps in order; each ends with a **CHECK** you should confirm before moving on.
 
-> ⚠️ **The automated path is not provisioned yet — follow the "By hand" steps throughout.** As of the `v0.5.0` release the automation has never run successfully because its CI secrets are not set up, so each automated step fails and has to be done by hand. **Do not start by triggering the automated workflows** — go straight to the by-hand steps in each section. The missing pieces:
->
-> - **Version bump (§1) and tag-on-merge (§2):** the `PR_AUTOMATION_BOT_PUBLIC_APP_ID` variable and `PR_AUTOMATION_BOT_PUBLIC_PRIVATE_KEY` secret. Without them both workflows fail at "Create GitHub App Token" (`private-key input must be set to a non-empty string`).
-> - **Staging deploy (§3):** the `DFX_DEPLOY_KEY_STAGING` secret. Without it the deploy fails at "Import deployment identity" (`Failed to validate pem file ... missing data`).
->
-> Until all three are provisioned, the by-hand flow is: §1 manual version-bump PR → §2 `./scripts/release` to tag → §3 manual `dfx canister install` to staging. Once the secrets are set up, the automated path below should work and this banner can be removed.
+> **Throwaway test release:** if you only need build artifacts, push any tag and the [Release](.github/workflows/release.yml) workflow builds them and creates a release for that tag. The steps below are for a full **production release**.
 
-## 1. Cut the release
+Canisters: `signer` is `tdxud-2yaaa-aaaad-aadiq-cai` on `staging` and `grghe-syaaa-aaaar-qabyq-cai` on `ic` (production).
 
-- Trigger the [Version Bump and Release Branch Creation](.github/workflows/bump-version.yml) workflow from the GitHub Actions tab, choosing the bump type (`patch | minor | major | alpha | beta | rc`).
-  - This runs `./scripts/version-bump`, which bumps `[workspace.package].version` in the root `Cargo.toml` and regenerates `Cargo.lock`, then opens a release PR from a `release/v*` branch.
-- Review and merge the release PR.
+## Preflight — have these ready before you start
 
-## 2. Tag, build, and publish
+- **GitHub:** `gh` authenticated; you can open and merge PRs, and a second person can approve (you cannot approve your own PR).
+- **Build tooling:** `cargo-edit` (`./scripts/setup cargo-edit`), Docker, and `bash >= 5` (for the reproducible `./scripts/docker-build`).
+- **Staging deploy (step 5):** a `dfx` identity that is a **controller of the staging canister**.
+- **Production proposal (steps 7–8):** `ic-admin` on your `PATH` (macOS needs the `darwin` build — see [HACKING.md](HACKING.md#local-tooling)), the **HSM connected with its PIN**, and your **NNS neuron ID** (the HSM identity must be a controller or hotkey of it). `propose` reads the neuron from `~/.config/dfx/prod-neuron` if present, otherwise prompts.
 
-On merge, the following chain runs automatically:
+---
 
-- [Tag on Merge from Release Branch](.github/workflows/tag-release.yml) tags the merge commit with `v<version>`.
-- [Release](.github/workflows/release.yml) builds the artifacts and creates a **draft** GitHub release.
-- [Deploy to Staging](.github/workflows/deploy-staging.yml) deploys the release artifacts to `staging` (see step 3).
+## 1. Cut the version-bump PR
 
-Then, by hand:
+1. `git fetch origin`, then create a fresh **worktree** off `origin/main` (keeps your main checkout clean) on branch `chore/release-<version>`.
+2. Ensure `cargo-edit` is present: `./scripts/setup cargo-edit`.
+3. Bump the version — choose the level by impact:
+   - **minor** for a behaviour change (e.g. fee-semantics changes: `0.4.0` added input UTXOs, `0.5.0` added output UTXOs).
+   - **patch** for fixes/maintenance only.
+   ```
+   ./scripts/version-bump [patch | minor | major | alpha | beta | rc]
+   ```
+   This bumps `[workspace.package].version` in the root `Cargo.toml` (inherited by `signer`, `ic-chain-fusion-signer-api`, `example_backend`) and regenerates `Cargo.lock`.
+4. Commit just those two files: `chore(release): Bump version to <version>`.
+5. Push and open a **draft** PR using the `Motivation` / `Changes` / `Tests` template.
 
-- Sanity check the draft release artifacts (the `report.txt` hashes and `commit.txt`).
-- Write the release notes.
-- Publish the release: `gh release edit v<version> --draft=false`.
+**CHECK:** the diff is version-only (Cargo.toml + the three crate versions in Cargo.lock); CI is green; you have one approving review. Then mark the PR ready and merge it.
 
-### By hand
+## 2. Tag the release
 
-Sections 1 and 2 can also be done by hand:
+1. `git checkout main && git pull --ff-only origin main`.
+2. Tag and build: `./scripts/release` — it tags the merge commit `v<version>`, pushes the tag, and watches the [Release](.github/workflows/release.yml) workflow build the artifacts.
 
-- Ensure the development tools in `dev-tools.json` are installed; in particular you may need `./scripts/setup cargo-edit`.
-- Create a release branch.
-- Bump the version with `./scripts/version-bump [patch | minor | major | alpha | beta | rc]` (default: `patch`), then merge the release branch.
-- Tag the merged commit with `./scripts/release`. This creates and pushes the tag; the Release GitHub action then builds the artifacts and creates the draft release.
-- Sanity check the artifacts, write the release notes, and publish the release (as above).
+**CHECK:** `Cargo.toml` shows `<version>` and `HEAD` is the merge commit; the Release workflow **succeeded**; a **draft** GitHub release exists with all assets (`signer.wasm.gz`, `report.txt`, `commit.txt`, `signer.did`, `signer.args.*`, `provenance.json`).
 
-## 3. Deploy to `staging`
-
-- This happens **automatically** when the Release workflow completes for a `v*` tag — **provided the `DFX_DEPLOY_KEY_STAGING` secret is set** (a controller identity of the staging canister, in PEM form). If it is missing the workflow fails at "Import deployment identity" (`Failed to validate pem file ... missing data`); use the **By hand** deploy below instead.
-- Because the release artifacts are built for the `ic` network, the workflow passes an explicit `Upgrade` argument so the existing staging configuration (e.g. `ecdsa_key_name = "test_key_1"`) is preserved instead of installing the `ic` init args.
-- The canister is upgraded with the `DFX_DEPLOY_KEY_STAGING` identity, which must be a controller of the staging canister.
-- Verify the upgrade:
-  - `dfx canister info signer --network staging` — the module hash matches the release Wasm hash, and `git:tags` / `git:commit` metadata are correct.
-  - `dfx canister call signer config --network staging` — the config still shows the staging values.
-- To deploy a different ref or rebuild from scratch, trigger the Deploy to Staging workflow manually from the GitHub Actions tab (it makes a fresh reproducible docker build).
-
-### By hand
-
-If you are a controller of the staging canister, deploy directly. The path below installs the **already-published, hash-verified release Wasm** — no local or docker build needed. It encodes the gotchas that otherwise turn this into a back-and-forth (verified working for `v0.5.0`):
+## 3. Verify the draft release artifacts
 
 ```
-# 0. Work from the release commit and confirm your identity controls staging:
-#      dfx identity get-principal   # must appear in:
-#      dfx canister info signer --network staging   # "Controllers:" list
+gh release download v<version> --pattern commit.txt --pattern report.txt
+```
 
-# 1. Download the release Wasm into the path dfx.json expects, then verify its
-#    sha256 against the release report.txt (the `out/signer.wasm.gz` line).
+**CHECK:** `commit.txt` equals `git rev-parse v<version>^{commit}`, and `report.txt` lists the sha256 of `out/signer.wasm.gz` and the arg files. **Note the wasm hash** — you will match it again in steps 5 and 7.
+
+## 4. Write release notes and publish
+
+1. Generate the auto changelog and curate it to match recent releases (a `Features` / `Fixes` / `Maintenance` summary on top, then the generated list and the `Full Changelog` compare link):
+   ```
+   gh api repos/dfinity/chain-fusion-signer/releases/generate-notes \
+     -f tag_name=v<version> -f previous_tag_name=v<previous> -q .body
+   ```
+2. Set the notes: `gh release edit v<version> --notes-file <file>`.
+3. Publish (public, **irreversible** — notifies watchers): `gh release edit v<version> --draft=false`.
+
+**CHECK:** the published release shows the curated notes and is no longer a draft.
+
+## 5. Deploy to `staging`
+
+If you are a controller of the staging canister, deploy directly. The path below installs the **already-published, hash-verified release Wasm** (no local or docker build needed) and encodes the gotchas that otherwise turn this into back-and-forth (verified for `v0.5.0`).
+
+```
+# a. Confirm your identity controls staging:
+dfx identity get-principal                          # must appear in the Controllers list of:
+dfx canister info signer --network staging
+
+# b. Download the release Wasm into the path dfx.json expects, and verify its hash:
 gh release download v<version> --pattern signer.wasm.gz --output out/signer.wasm.gz --clobber
-shasum -a 256 out/signer.wasm.gz   # must equal the hash in report.txt
+shasum -a 256 out/signer.wasm.gz                    # must equal the report.txt hash from step 3
 
-# 2. Create the dfx workspace dir so dfx can RUN its Candid compat check instead of
-#    falling back to an interactive prompt (which a non-interactive shell auto-declines):
+# c. Create the dfx workspace dir so dfx can RUN its Candid compat check instead of falling
+#    back to an interactive prompt (which a non-interactive shell auto-declines):
 mkdir -p .dfx/staging/canisters/signer
 
-# 3. CRITICAL — neutralize the init args. dfx.json sets `init_arg_file: out/signer.args.did`,
+# d. CRITICAL — neutralize the init args. dfx.json sets `init_arg_file: out/signer.args.did`,
 #    which holds the *production* args (`ecdsa_key_name = "key_1"`). dfx reads that file and
-#    IGNORES a `--argument` flag, so you must overwrite the file with `(null)`, otherwise the
-#    upgrade repoints staging at the production key. `(null)` => `post_upgrade(None)` => the
-#    existing staging config (`test_key_1`) is preserved.
+#    IGNORES a `--argument` flag, so you must overwrite it with `(null)`, or the upgrade would
+#    repoint staging at the production key. `(null)` => `post_upgrade(None)` => staging config kept.
 printf '(null)\n' > out/signer.args.did
 
-# 4. Install the upgrade. `--wasm` installs the pre-built module directly; `--yes` confirms
-#    past dfx's Candid check (benign here — the interface is unchanged across a pricing-only
-#    release; for any release, diff the deployed candid vs the new `signer.did` to be sure).
+# e. Install the upgrade (`--wasm` installs the prebuilt module; `--yes` confirms past the
+#    benign Candid check — the interface is unchanged for a pricing-only release; for any
+#    release, diff the deployed candid vs the new signer.did to be sure):
 dfx canister install signer --wasm out/signer.wasm.gz \
   --mode upgrade --upgrade-unchanged --network staging --yes
 ```
 
-Then verify (as in the bullets above): the module hash equals the release Wasm hash, `git:tags`/`git:commit` are correct, and `dfx canister call signer config --network staging` still shows `ecdsa_key_name = "test_key_1"` (**not** `key_1`).
+**CHECK** (prefix queries with `DFX_WARNING=-mainnet_plaintext_identity` if a plaintext-identity confirmation appears):
+- `dfx canister info signer --network staging` → **module hash equals the release wasm hash** (step 3); `git:tags` = `v<version>`, `git:commit` = the release commit.
+- `dfx canister call signer config --network staging` → still `ecdsa_key_name = "test_key_1"` (**not** `key_1`).
 
-> If `dfx canister metadata` / `info` queries trigger a mainnet plaintext-identity confirmation, prefix the command with `DFX_WARNING=-mainnet_plaintext_identity`.
+> Alternative: rebuild from scratch with `./scripts/docker-build` and install the same way — but the published Wasm is already that reproducible artifact, so downloading it is simpler and provably identical. If you are not a controller, request the upgrade via Orbit (contact the Orbit team).
 
-Alternatively, rebuild from scratch with `./scripts/docker-build` and install the same way — but the published Wasm is already that reproducible artifact, so downloading it (step 1) is simpler and provably identical.
+## 6. Test on staging
 
-If you are not a controller, you may request a canister upgrade via Orbit; contact the Orbit team for the latest Orbit deployment instructions.
+Exercise the real signing flow against staging via [staging.oisy.com](https://staging.oisy.com) (it is wired to the staging signer). Make a **signed transaction**; for a fee-related change, use the BTC send path specifically.
 
-## 4. Upgrade production (NNS proposal)
+**CHECK:** the transaction signs and sends successfully end-to-end.
 
-> ⚠️ **The [Prepare Production Proposal](.github/workflows/prepare-proposal.yml) workflow is currently broken** — its "Build reproducibly" step runs `git log | head -n1` under `set -o pipefail`, so `git log` gets SIGPIPE and the step fails with exit code 141 (fix: use `git log -1 --format=%H`). Until that is fixed, prepare the proposal with the **by-hand scripts** below; they do exactly the same work locally and are the path verified for `v0.5.0`.
+## 7. Prepare the production proposal (safe dry run)
 
-- Ensure the GitHub release for the tag has been **published** (step 2).
-- Trigger the [Prepare Production Proposal](.github/workflows/prepare-proposal.yml) workflow with the release tag. It downloads the release assets, runs a reproducible docker build, verifies the Wasm and argument hashes match the release, generates `release/PROPOSAL.md` and `release/ROLLBACK.md`, and uploads everything as the `proposal-$TAG` workflow artifact.
-- On your machine (see prerequisites below):
-  - Check out the release commit.
-  - Delete any old `release/` directory and download the `proposal-$TAG` artifact into `release/`.
-  - Install `ic-admin`: `./scripts/setup ic-admin`.
-  - Review `release/PROPOSAL.md` and `release/ROLLBACK.md`.
-  - Run `./scripts/propose`, review the printed `ic-admin` command very carefully, then submit.
-- Schedule an appointment with trusted neurons to vote on the proposal.
-
-### Local prerequisites for submitting the proposal
-
-`./scripts/propose` runs `ic-admin` and signs the NNS submission with an HSM. For installing the local tooling (`ic-admin`, Docker, bash), see [HACKING.md](HACKING.md#local-tooling). Before running it, make sure:
-
-- **`ic-admin`** is installed and on your `PATH` (macOS needs the `darwin` build — see the tooling notes linked above).
-- The **HSM is connected** and you have its PIN. For the `ic` network, `propose` authenticates with `--use-hsm --key-id 01 --slot 0` and prompts for the PIN.
-- Your **NNS neuron ID** is ready. `propose` reads it from `~/.config/dfx/prod-neuron` if present, otherwise it prompts. The HSM identity must be a controller or hotkey of that neuron.
-- **`gh`** is authenticated (used to download release assets) and **`dfx`** is installed.
-
-### Running the proposal scripts by hand
-
-Run these from an up-to-date `main` checkout (you pick up the latest tooling fixes; the scripts target the release via `-t v<version>` and need not run from the release commit). The first three steps are a **safe dry run** — they download, build, and template only; nothing touches the HSM or gets submitted, so you can review everything in advance. They additionally require **Docker** and **bash >= 5** (see the tooling notes linked above).
+Run from an up-to-date `main` checkout. These three steps only download, build, and template — **nothing touches the HSM or gets submitted**, so review everything first.
 
 ```
-# 1. Download the published release assets into release/ci/ (prints their sha256sums).
+# a. Download the published release assets into release/ci/ (prints their sha256sums):
 ./scripts/proposal-assets -t v<version>
 
-# 2. Reproduce the build locally and verify it is bit-for-bit identical to the release.
-#    out/signer.wasm.gz must equal the `out/signer.wasm.gz` hash in release/ci/report.txt;
-#    out/signer.args.{did,bin} must equal the matching release/ci files.
+# b. Reproduce the build and verify it is bit-for-bit identical to the release:
 ./scripts/docker-build
-sha256sum out/signer.wasm.gz   # compare against release/ci/report.txt
+sha256sum out/signer.wasm.gz                        # must equal release/ci/report.txt
+#    (out/signer.args.{did,bin} must also equal the matching release/ci files)
 
-# 3. Generate the proposal text and review it.
+# c. Generate the proposal text:
 ./scripts/proposal-template -t v<version>
-#    -> release/PROPOSAL.md  (upgrade to v<version>: target canister, wasm + arg hashes, changelog)
+#    -> release/PROPOSAL.md  (upgrade: target canister, wasm + arg hashes, changelog)
 #    -> release/ROLLBACK.md  (revert to the previous version)
 ```
 
-Sanity-check `release/PROPOSAL.md`: the wasm hash matches step 2, the **Candid/binary arg hashes are the production args** (`ecdsa_key_name = "key_1"`, not `test_key_1`), and `release/ROLLBACK.md` points at the version currently on production.
+**CHECK** `release/PROPOSAL.md`: the wasm hash matches step b; the **Candid/binary arg hashes are the production args** (`ecdsa_key_name = "key_1"`, not `test_key_1`); the target is `grghe-syaaa-aaaar-qabyq-cai`; and `release/ROLLBACK.md` points at the version currently on production.
 
-Then submit (HSM-gated — see prerequisites above):
+## 8. Submit the proposal (HSM-gated)
+
+With the HSM connected and your neuron ready:
 
 ```
-# 4. Builds the ic-admin command, prints it for review, then signs with the HSM and submits.
 ./scripts/propose
 ```
 
-> Note: `out/` and `release/ci/` are build outputs left in the working tree by the dry run — harmless, git-ignored, and overwritten on the next run.
+It builds the `ic-admin` command, **prints it for review** (it authenticates with `--use-hsm --key-id 01 --slot 0` and prompts for the PIN), then signs and submits.
+
+**CHECK:** before confirming, read the printed command carefully — target canister `grghe-syaaa-aaaar-qabyq-cai`, the wasm hash from step 3/7, and your neuron ID. After submission, confirm the proposal is listed on the NNS.
+
+## 9. Get it voted in
+
+Schedule an appointment with trusted neurons to vote on the proposal.
+
+---
+
+## Automation (once secrets are provisioned)
+
+The repo ships a CI chain that is meant to replace the by-hand steps above, but **it has never run successfully** because its secrets are not set up. Until they are, use the runbook above. The intended flow and the missing pieces:
+
+- **Step 1 — [Version Bump and Release Branch Creation](.github/workflows/bump-version.yml)** (opens the release PR) and **step 2 — [Tag on Merge from Release Branch](.github/workflows/tag-release.yml)** (tags on merge) authenticate as a GitHub App via the `PR_AUTOMATION_BOT_PUBLIC_APP_ID` variable and `PR_AUTOMATION_BOT_PUBLIC_PRIVATE_KEY` secret. Missing → both fail at "Create GitHub App Token" (`private-key input must be set to a non-empty string`).
+- **Step 5 — [Deploy to Staging](.github/workflows/deploy-staging.yml)** runs automatically when Release completes for a `v*` tag, using the `DFX_DEPLOY_KEY_STAGING` secret (a controller identity in PEM form). Missing → fails at "Import deployment identity" (`Failed to validate pem file ... missing data`).
+- **Step 7 — [Prepare Production Proposal](.github/workflows/prepare-proposal.yml)** would generate the proposal artifact, but its "Build reproducibly" step runs `git log | head -n1` under `set -o pipefail`, so `git log` gets SIGPIPE and it fails with exit code 141 (fix: `git log -1 --format=%H`).
+- The **Release** build (`GITHUB_TOKEN`) and the staging deploy's payment of cycles are unaffected.
+
+Once the three credentials are provisioned and the `prepare-proposal` step is fixed, the automated path should work; update this runbook to lead with it.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -53,25 +53,41 @@ Sections 1 and 2 can also be done by hand:
 
 ### By hand
 
-If you are a controller of the staging canister, you can deploy directly.
-
-A quick deploy (builds locally for the `staging` network, so it uses the correct staging args):
+If you are a controller of the staging canister, deploy directly. The path below installs the **already-published, hash-verified release Wasm** — no local or docker build needed. It encodes the gotchas that otherwise turn this into a back-and-forth (verified working for `v0.5.0`):
 
 ```
-dfx deploy signer --network staging
+# 0. Work from the release commit and confirm your identity controls staging:
+#      dfx identity get-principal   # must appear in:
+#      dfx canister info signer --network staging   # "Controllers:" list
+
+# 1. Download the release Wasm into the path dfx.json expects, then verify its
+#    sha256 against the release report.txt (the `out/signer.wasm.gz` line).
+gh release download v<version> --pattern signer.wasm.gz --output out/signer.wasm.gz --clobber
+shasum -a 256 out/signer.wasm.gz   # must equal the hash in report.txt
+
+# 2. Create the dfx workspace dir so dfx can RUN its Candid compat check instead of
+#    falling back to an interactive prompt (which a non-interactive shell auto-declines):
+mkdir -p .dfx/staging/canisters/signer
+
+# 3. CRITICAL — neutralize the init args. dfx.json sets `init_arg_file: out/signer.args.did`,
+#    which holds the *production* args (`ecdsa_key_name = "key_1"`). dfx reads that file and
+#    IGNORES a `--argument` flag, so you must overwrite the file with `(null)`, otherwise the
+#    upgrade repoints staging at the production key. `(null)` => `post_upgrade(None)` => the
+#    existing staging config (`test_key_1`) is preserved.
+printf '(null)\n' > out/signer.args.did
+
+# 4. Install the upgrade. `--wasm` installs the pre-built module directly; `--yes` confirms
+#    past dfx's Candid check (benign here — the interface is unchanged across a pricing-only
+#    release; for any release, diff the deployed candid vs the new `signer.did` to be sure).
+dfx canister install signer --wasm out/signer.wasm.gz \
+  --mode upgrade --upgrade-unchanged --network staging --yes
 ```
 
-Or deploy a reproducible docker build:
+Then verify (as in the bullets above): the module hash equals the release Wasm hash, `git:tags`/`git:commit` are correct, and `dfx canister call signer config --network staging` still shows `ecdsa_key_name = "test_key_1"` (**not** `key_1`).
 
-```
-# Reproducible build; artifacts are placed in ./out/ (same location as `dfx build signer --ic`).
-./scripts/docker-build
+> If `dfx canister metadata` / `info` queries trigger a mainnet plaintext-identity confirmation, prefix the command with `DFX_WARNING=-mainnet_plaintext_identity`.
 
-# Inspect the Wasm and install arguments in ./out/, then deploy:
-dfx canister install signer --mode upgrade --upgrade-unchanged --argument '(null)' --network staging
-```
-
-Note: the docker build produces `ic` install args, so pass `--argument '(null)'` to `dfx canister install` to preserve the existing staging configuration (an `Upgrade` argument), the same way the automated workflow does — installing the `ic` args would otherwise overwrite the staging key.
+Alternatively, rebuild from scratch with `./scripts/docker-build` and install the same way — but the published Wasm is already that reproducible artifact, so downloading it (step 1) is simpler and provably identical.
 
 If you are not a controller, you may request a canister upgrade via Orbit; contact the Orbit team for the latest Orbit deployment instructions.
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -4,9 +4,14 @@ A concise, end-to-end checklist for cutting a new release, deploying to `staging
 
 For a throwaway **test release**, just push any tag and the [Release](.github/workflows/release.yml) workflow builds the artifacts and creates a release for that tag. The sections below describe a full **production release**.
 
-## 1. Cut the release
+> ⚠️ **The automated path is not provisioned yet — follow the "By hand" steps throughout.** As of the `v0.5.0` release the automation has never run successfully because its CI secrets are not set up, so each automated step fails and has to be done by hand. **Do not start by triggering the automated workflows** — go straight to the by-hand steps in each section. The missing pieces:
+>
+> - **Version bump (§1) and tag-on-merge (§2):** the `PR_AUTOMATION_BOT_PUBLIC_APP_ID` variable and `PR_AUTOMATION_BOT_PUBLIC_PRIVATE_KEY` secret. Without them both workflows fail at "Create GitHub App Token" (`private-key input must be set to a non-empty string`).
+> - **Staging deploy (§3):** the `DFX_DEPLOY_KEY_STAGING` secret. Without it the deploy fails at "Import deployment identity" (`Failed to validate pem file ... missing data`).
+>
+> Until all three are provisioned, the by-hand flow is: §1 manual version-bump PR → §2 `./scripts/release` to tag → §3 manual `dfx canister install` to staging. Once the secrets are set up, the automated path below should work and this banner can be removed.
 
-> **Prerequisite for the automated path.** Both the [Version Bump and Release Branch Creation](.github/workflows/bump-version.yml) and [Tag on Merge from Release Branch](.github/workflows/tag-release.yml) workflows authenticate as a GitHub App, using the `PR_AUTOMATION_BOT_PUBLIC_APP_ID` repository (or org) variable and the `PR_AUTOMATION_BOT_PUBLIC_PRIVATE_KEY` secret. If these are not provisioned, both workflows fail immediately at the "Create GitHub App Token" step (`private-key input must be set to a non-empty string`). Until they are set up, use the **By hand** steps below instead.
+## 1. Cut the release
 
 - Trigger the [Version Bump and Release Branch Creation](.github/workflows/bump-version.yml) workflow from the GitHub Actions tab, choosing the bump type (`patch | minor | major | alpha | beta | rc`).
   - This runs `./scripts/version-bump`, which bumps `[workspace.package].version` in the root `Cargo.toml` and regenerates `Cargo.lock`, then opens a release PR from a `release/v*` branch.
@@ -38,7 +43,7 @@ Sections 1 and 2 can also be done by hand:
 
 ## 3. Deploy to `staging`
 
-- This happens **automatically** when the Release workflow completes for a `v*` tag.
+- This happens **automatically** when the Release workflow completes for a `v*` tag — **provided the `DFX_DEPLOY_KEY_STAGING` secret is set** (a controller identity of the staging canister, in PEM form). If it is missing the workflow fails at "Import deployment identity" (`Failed to validate pem file ... missing data`); use the **By hand** deploy below instead.
 - Because the release artifacts are built for the `ic` network, the workflow passes an explicit `Upgrade` argument so the existing staging configuration (e.g. `ecdsa_key_name = "test_key_1"`) is preserved instead of installing the `ic` init args.
 - The canister is upgraded with the `DFX_DEPLOY_KEY_STAGING` identity, which must be a controller of the staging canister.
 - Verify the upgrade:


### PR DESCRIPTION
# Motivation

This document was not very helpful when using it again after the creation.

The automated release path in `RELEASE.md` (step 1) tells you to trigger the Version Bump workflow, but does not mention that both `bump-version.yml` and `tag-release.yml` require a GitHub App token. When the `PR_AUTOMATION_BOT_PUBLIC_APP_ID` variable and `PR_AUTOMATION_BOT_PUBLIC_PRIVATE_KEY` secret are not provisioned, both workflows fail immediately at "Create GitHub App Token", and the manual following the checklist has no way to know why or what to do instead.

# Changes

- Add a prerequisite note at the top of `RELEASE.md` §1 naming the required app-id variable and private-key secret, the exact failure that occurs when they are missing, and a pointer to the **By hand** steps as the fallback.

# Tests

N/A — documentation only.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code) (Opus 4.8)