### PR TITLE
feat(scripts): Use (variant { Upgrade }) for upgrade proposals

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -38,6 +38,8 @@ jobs:
           fetch-depth: 0
       - name: Install tools
         run: sudo apt-get install -yy shellcheck
+      - name: Install didc
+        run: ./scripts/setup didc
       - name: Lint shell
         run: ./scripts/lint-sh
       - name: Shell commands work

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -13,7 +13,7 @@ Canisters: `signer` is `tdxud-2yaaa-aaaad-aadiq-cai` on `staging` and `grghe-sya
 - **GitHub:** `gh` authenticated; you can open and merge PRs, and a second person can approve (you cannot approve your own PR).
 - **Build tooling:** `cargo-edit` (`./scripts/setup cargo-edit`), Docker, and `bash >= 5` (for the reproducible `./scripts/docker-build`).
 - **Staging deploy (step 5):** a `dfx` identity that is a **controller of the staging canister**.
-- **Production proposal (steps 7–8):** `ic-admin` on your `PATH` (macOS needs the `darwin` build — see [HACKING.md](HACKING.md#local-tooling)), the **HSM connected with its PIN**, and your **NNS neuron ID** (the HSM identity must be a controller or hotkey of it). `propose` reads the neuron from `~/.config/dfx/prod-neuron` if present, otherwise prompts.
+- **Production proposal (steps 7–8):** `ic-admin` and `didc` on your `PATH` (`./scripts/setup ic-admin didc`; macOS needs the `darwin`/`macos` builds — see [HACKING.md](HACKING.md#local-tooling)), the **HSM connected with its PIN**, and your **NNS neuron ID** (the HSM identity must be a controller or hotkey of it). `propose` reads the neuron from `~/.config/dfx/prod-neuron` if present, otherwise prompts.
 
 ---
 
@@ -122,7 +122,9 @@ sha256sum out/signer.wasm.gz                        # must equal release/ci/repo
 #    -> release/ROLLBACK.md  (revert to the previous version)
 ```
 
-**CHECK** `release/PROPOSAL.md`: the wasm hash matches step b; the **Candid/binary arg hashes are the production args** (`ecdsa_key_name = "key_1"`, not `test_key_1`); the target is `grghe-syaaa-aaaar-qabyq-cai`; and `release/ROLLBACK.md` points at the version currently on production.
+`proposal-template` runs `build.upgrade.args.sh` (which needs `didc`) to produce the upgrade argument, so `PROPOSAL.md` records the `(variant { Upgrade })` argument rather than the `Init` args (see [Init vs Upgrade argument](#init-vs-upgrade-argument) below).
+
+**CHECK** `release/PROPOSAL.md`: the wasm hash matches step b; the **upgrade argument is `(variant { Upgrade })`** with binary arg hash `100d1390b7762eef1bc2af9d6fdd157bb800bfc3787142c435d4c28747d0ac30` (constant for every upgrade); the target is `grghe-syaaa-aaaar-qabyq-cai`; and `release/ROLLBACK.md` points at the version currently on production.
 
 ## 8. Submit the proposal (HSM-gated)
 
@@ -134,11 +136,24 @@ With the HSM connected and your neuron ready:
 
 It builds the `ic-admin` command, **prints it for review** (it authenticates with `--use-hsm --key-id 01 --slot 0` and prompts for the PIN), then signs and submits.
 
-**CHECK:** before confirming, read the printed command carefully — target canister `grghe-syaaa-aaaar-qabyq-cai`, the wasm hash from step 3/7, and your neuron ID. After submission, confirm the proposal is listed on the NNS.
+**CHECK:** before confirming, read the printed command carefully — target canister `grghe-syaaa-aaaar-qabyq-cai`, `--mode upgrade`, the wasm hash from step 3/7, `--arg-sha256 100d1390…` (the `(variant { Upgrade })` argument), and your neuron ID. After submission, confirm the proposal is listed on the NNS.
 
 ## 9. Get it voted in
 
 Schedule an appointment with trusted neurons to vote on the proposal.
+
+---
+
+## Init vs Upgrade argument
+
+The canister's install argument is `type Arg = variant { Upgrade; Init : InitArg }`, and `post_upgrade` treats them very differently ([`src/signer/canister/src/lib.rs`](src/signer/canister/src/lib.rs)):
+
+- `Init : record { … }` → calls `set_config`, which **replaces the entire config** with a `Config` derived from those fields.
+- `Upgrade` (or no argument) → **keeps the existing config** untouched.
+
+Therefore **upgrade proposals must use `(variant { Upgrade })`**, not the `Init` args. Submitting `Init` on an upgrade re-applies the full config and would silently overwrite any field that differs from the baked-in args (e.g. a non-default root key or cycles ledger). The `Init` args (`scripts/build.signer.args.sh`, written to `out/signer.args.*`) are only for the **initial installation**; the staging deploy (step 5) achieves the same "keep config" effect by passing `(null)`.
+
+`scripts/propose` and `scripts/proposal-template` both call `scripts/build.upgrade.args.sh`, which encodes `(variant { Upgrade })` with `didc` — a constant, network-independent value (binary sha256 `100d1390…`). Anyone can reproduce it with `didc encode '(variant { Upgrade })'`.
 
 ---
 

--- a/scripts/build.upgrade.args.sh
+++ b/scripts/build.upgrade.args.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+print_help() {
+  cat <<-EOF
+	Creates the Chain Fusion Signer **upgrade** argument: '(variant { Upgrade })'.
+
+	Unlike the Init args (see build.signer.args.sh), this argument is
+	network-independent and tells the canister's post_upgrade hook to keep the
+	existing configuration. Use it for every upgrade proposal; the Init args are
+	only for the initial installation, and submitting them on an upgrade would
+	overwrite the whole canister config.
+
+	Usage: build.upgrade.args.sh [OUTPUT_DID_PATH]
+	  OUTPUT_DID_PATH defaults to out/signer.upgrade.args.did
+	  The matching .hex and .bin files are written alongside it.
+	EOF
+}
+
+[[ "${1:-}" != "--help" ]] || {
+  print_help
+  exit 0
+}
+
+ARG_DID="${1:-out/signer.upgrade.args.did}"
+ARG_HEX="${ARG_DID%.did}.hex"
+ARG_BIN="${ARG_DID%.did}.bin"
+
+mkdir -p "$(dirname "$ARG_DID")"
+echo '(variant { Upgrade })' >"$ARG_DID"
+didc encode "$(cat "$ARG_DID")" | tee "$ARG_HEX" | xxd -r -p >"$ARG_BIN"
+
+cat <<EOF
+SUCCESS: The signer upgrade argument file has been created:
+signer upgrade args as candid: $(sha256sum "$ARG_DID")
+signer upgrade args as binary: $(sha256sum "$ARG_BIN")
+EOF

--- a/scripts/proposal-template
+++ b/scripts/proposal-template
@@ -80,26 +80,21 @@ else
   echo "Please populate ${WASM} and run this again."
   exit 0
 fi
-ARGS_DID="release/ci/signer.args.did"
-if test -f "$ARGS_DID"; then
-  ARGS_DID_SHA="$(sha256sum "$ARGS_DID" | awk '{print $1}')"
-else
-  echo "Please populate ${ARGS_DID} and run this again."
-  exit 0
-fi
-ARGS_BIN="release/ci/signer.args.bin"
-if test -f "$ARGS_BIN"; then
-  ARGS_BIN_SHA="$(sha256sum "$ARGS_BIN" | awk '{print $1}')"
-else
-  echo "Please populate ${ARGS_BIN} and run this again."
-  exit 0
-fi
+# Upgrade proposals use the network-independent `(variant { Upgrade })` argument, which
+# preserves the canister's existing configuration. (The Init args in release/ci are only
+# for the initial installation; submitting them on an upgrade would overwrite the config.)
+ARGS_DID="release/signer.upgrade.args.did"
+build.upgrade.args.sh "$ARGS_DID" >&2
+ARGS_DID_SHA="$(sha256sum "$ARGS_DID" | awk '{print $1}')"
+ARGS_BIN="${ARGS_DID%.did}.bin"
+ARGS_BIN_SHA="$(sha256sum "$ARGS_BIN" | awk '{print $1}')"
 
 cat <<EOF >"$OUTPUT_PROPOSAL"
 # Upgrade Chain Fusion Signer canister to $RELEASE_CANDIDATE_TAG
 Commit: \`$(git rev-parse "tags/$RELEASE_CANDIDATE_TAG")\`
 Release: \`${RELEASE_GITHUB_URL}\`
 Wasm sha256 hash: \`${WASM_SHA}\`
+Upgrade argument: \`(variant { Upgrade })\` (preserves the existing canister configuration)
 Candid argument hash: \`${ARGS_DID_SHA}\`
 Binary argument hash: \`${ARGS_BIN_SHA}\`
 

--- a/scripts/proposal-template.test.proposal.txt
+++ b/scripts/proposal-template.test.proposal.txt
@@ -2,8 +2,9 @@
 Commit: `e1c36f468c7b78e851332cc7dae0bfce6bc8f886`
 Release: `https://github.com/dfinity/chain-fusion-signer/releases/tag/v0.2.8`
 Wasm sha256 hash: `9d76ee4646df62d1a4bddbdfb4fa78e43166c19a94595ba9e1f5f27b823c8192`
-Candid argument hash: `a99d4a8355c86d2367955d833df83302b5748e6e34898e280e359f9c57541e1f`
-Binary argument hash: `367a11245d7e97692843c69e9582dd8ad08eef1ff3392dfd0c944d5f1bd74a41`
+Upgrade argument: `(variant { Upgrade })` (preserves the existing canister configuration)
+Candid argument hash: `5ea6172390cb0bdb8cec26a66cb6ce18f714c7f842fddec6e87ef2ad31289b04`
+Binary argument hash: `100d1390b7762eef1bc2af9d6fdd157bb800bfc3787142c435d4c28747d0ac30`
 
 The chain fusion signer is a canister that makes the internet computer threshold signing API available to web applications, off-chain clients and other-chain applications.
 

--- a/scripts/propose
+++ b/scripts/propose
@@ -111,12 +111,13 @@ fi
 WASM="release/ci/signer.wasm.gz"
 WASM_SHA="$(sha256sum <"$WASM" | awk '{print $1}')"
 
-# Gets the canister arguments
-ARG_PATH=release/ci/signer.args.bin
-test -e "$ARG_PATH" || {
-  echo "ERROR: Arguments need to be provided in $ARG_PATH"
-  exit 1
-} >&2
+# Gets the canister upgrade argument.
+# Upgrades use the network-independent `(variant { Upgrade })` argument, which tells the
+# canister's post_upgrade hook to keep the existing configuration. The Init args in
+# release/ci are only for the initial installation; submitting them on an upgrade would
+# overwrite the whole canister config (see RELEASE.md, "Init vs Upgrade argument").
+ARG_PATH=release/signer.upgrade.args.bin
+build.upgrade.args.sh "release/signer.upgrade.args.did" >&2
 
 ARG_SHA="$(sha256sum <"$ARG_PATH" | awk '{print $1}')"
 


### PR DESCRIPTION
# Motivation

A reviewer flagged the production proposal argument: it submitted the `Init` args

```
(variant { Init = record { ecdsa_key_name = "key_1"; ic_root_key_der = null; cycles_ledger = opt principal "um5iw-rqaaa-aaaaq-qaaba-cai" } })
```

but for an upgrade the canister's `post_upgrade` does `match arg { Some(Arg::Init(arg)) => set_config(arg), _ => /* keep config */ }` (`src/signer/canister/src/lib.rs`). `set_config` **replaces the entire config**, so passing `Init` re-applies the full config on every upgrade and would silently overwrite any field that differs from the baked-in args. It only happens to be safe today because the args match the live config (e.g. `ic_root_key_der = null` resolves to the same hard-coded mainnet root key).

The correct, intention-revealing argument for an upgrade is `(variant { Upgrade })` (or `null`), which preserves the existing config. The staging deploy already does this by passing `(null)`; this brings the production proposal in line.

# Changes

- Add `scripts/build.upgrade.args.sh`, which encodes the network-independent `(variant { Upgrade })` argument with `didc` (constant binary sha256 `100d1390…`).
- `scripts/propose` and `scripts/proposal-template` now use that upgrade argument instead of `release/ci/signer.args.bin`. The `Init` args remain a build output for the initial install only.
- `PROPOSAL.md` now records `Upgrade argument: (variant { Upgrade })` and its hashes; the `proposal-template` golden file is updated accordingly.
- `ci`: the `sh-tests` job installs `didc` (`.github/workflows/check.yml`), since `proposal-template.test` now needs it.
- `RELEASE.md`: add an "Init vs Upgrade argument" section, note `didc` in the preflight, and correct the step 7/8 expectations.

# Tests

- CI `Format`, `Rust tests`, and `Shell tests` (which runs `proposal-template.test` with `didc`) all pass.
- Locally: `./scripts/proposal-template.test` passes (regenerated golden file); `shfmt -i 2 -d` and `shellcheck -e SC1090 -e SC2119 -e SC1091` clean on the changed scripts; Prettier clean on `RELEASE.md`.
- Verified `didc encode '(variant { Upgrade })'` -> `4449444c016b01fcb88b84037f010000` (binary sha256 `100d1390b7762eef1bc2af9d6fdd157bb800bfc3787142c435d4c28747d0ac30`).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code) (Opus 4.8)