### PR TITLE
feat(signer): add btc_sign_prehash to sign an arbitrary digest under the BTC key

### DIFF
--- a/src/signer/api/src/methods.rs
+++ b/src/signer/api/src/methods.rs
@@ -10,6 +10,7 @@ pub enum SignerMethods {
     BtcCallerBalance,
     BtcCallerSend,
     BtcCallerSign,
+    BtcSignPrehash,
     SchnorrPublicKey,
     SchnorrSign,
 }
@@ -43,6 +44,8 @@ impl SignerMethods {
             // Grace-period default sized for a 2-input transaction:
             // btc_base_fee() + 2 * btc_per_input_fee() = 74 B + 2 * 37 B = 148 B
             SignerMethods::BtcCallerSign => 148_000_000_000,
+            // Flat: one `sign_with_ecdsa` over a single prehash, no transaction building.
+            SignerMethods::BtcSignPrehash => 37_000_000_000,
             SignerMethods::EthAddress | SignerMethods::EthAddressOfCaller => 77_000_000,
             SignerMethods::EthPersonalSign => 37_000_000_000,
             SignerMethods::EthSignPrehash => 37_000_000_000,

--- a/src/signer/api/src/types.rs
+++ b/src/signer/api/src/types.rs
@@ -151,6 +151,8 @@ pub mod bitcoin {
 
     #[derive(CandidType, Deserialize, Debug)]
     pub enum BtcSignPrehashError {
+        /// The supplied hash was not valid hex or was not a 32-byte digest.
+        InvalidHash { msg: String },
         /// Payment failed.
         PaymentError(PaymentError),
         /// An inter-canister call error from the threshold signature API.

--- a/src/signer/api/src/types.rs
+++ b/src/signer/api/src/types.rs
@@ -134,4 +134,36 @@ pub mod bitcoin {
         PaymentError(PaymentError),
         BuildP2wpkhError(BuildP2wpkhTxError),
     }
+
+    #[derive(CandidType, Deserialize, Debug)]
+    pub struct BtcSignPrehashRequest {
+        /// Hex-encoded 32-byte digest to sign under the caller's Bitcoin key.
+        pub hash: String,
+    }
+
+    #[derive(CandidType, Deserialize, Debug)]
+    pub struct BtcSignPrehashResponse {
+        /// Hex-encoded 64-byte ECDSA signature (`r || s`), as returned by the management canister.
+        /// The caller recovers the recovery id (and any encoding it needs) from the known public
+        /// key.
+        pub signature: String,
+    }
+
+    #[derive(CandidType, Deserialize, Debug)]
+    pub enum BtcSignPrehashError {
+        /// Payment failed.
+        PaymentError(PaymentError),
+        /// An inter-canister call error from the threshold signature API.
+        SigningError(String),
+    }
+    impl From<PaymentError> for BtcSignPrehashError {
+        fn from(e: PaymentError) -> Self {
+            Self::PaymentError(e)
+        }
+    }
+    impl From<String> for BtcSignPrehashError {
+        fn from(msg: String) -> Self {
+            Self::SigningError(msg)
+        }
+    }
 }

--- a/src/signer/canister/signer.did
+++ b/src/signer/canister/signer.did
@@ -6,6 +6,21 @@ type Bip341 = record {
   merkle_root_hash : blob;
 };
 type BitcoinAddressType = variant { P2WPKH };
+type BtcSignPrehashError = variant {
+  // An inter-canister call error from the threshold signature API.
+  SigningError : text;
+  // Payment failed.
+  PaymentError : PaymentError;
+};
+type BtcSignPrehashRequest = record {
+  // Hex-encoded 32-byte digest to sign under the caller's Bitcoin key.
+  hash : text;
+};
+type BtcSignPrehashResponse = record {
+  // Hex-encoded 64-byte ECDSA signature (`r || s`), as returned by the management canister.
+  // The caller recovers the recovery id (and any encoding it needs) from the known public key.
+  signature : text;
+};
 type BtcTxOutput = record { destination_address : text; sent_satoshis : nat64 };
 type BuildP2wpkhTxError = variant {
   NotEnoughFunds : record { available : nat64; required : nat64 };
@@ -216,24 +231,28 @@ type RejectionCode = variant {
 type Result = variant { Ok : GetAddressResponse; Err : GetAddressError };
 type Result_1 = variant { Ok : GetBalanceResponse; Err : GetAddressError };
 type Result_10 = variant {
+  Ok : record { EcdsaPublicKeyResult };
+  Err : EthAddressError;
+};
+type Result_11 = variant {
   Ok : record { SignWithEcdsaResult };
   Err : EthAddressError;
 };
 type Result_2 = variant { Ok : SendBtcResponse; Err : SendBtcError };
 type Result_3 = variant { Ok : SignBtcResponse; Err : SendBtcError };
-type Result_4 = variant { Ok : EthAddressResponse; Err : EthAddressError };
-type Result_5 = variant { Ok : EthPersonalSignResponse; Err : EthAddressError };
-type Result_6 = variant { Ok : EthSignPrehashResponse; Err : EthAddressError };
-type Result_7 = variant {
-  Ok : record { EcdsaPublicKeyResult };
-  Err : EthAddressError;
+type Result_4 = variant {
+  Ok : BtcSignPrehashResponse;
+  Err : BtcSignPrehashError;
 };
+type Result_5 = variant { Ok : EthAddressResponse; Err : EthAddressError };
+type Result_6 = variant { Ok : EthPersonalSignResponse; Err : EthAddressError };
+type Result_7 = variant { Ok : EthSignPrehashResponse; Err : EthAddressError };
 type Result_8 = variant {
-  Ok : record { SignWithEcdsaResult };
+  Ok : record { EcdsaPublicKeyResult };
   Err : EthAddressError;
 };
 type Result_9 = variant {
-  Ok : record { EcdsaPublicKeyResult };
+  Ok : record { SignWithEcdsaResult };
   Err : EthAddressError;
 };
 // # Schnorr Algorithm.
@@ -398,6 +417,25 @@ service : (Arg) -> {
   // # Panics
   // - If the caller is the anonymous user.
   btc_caller_sign : (SendBtcRequest, opt PaymentType) -> (Result_3);
+  // Signs a precomputed 32-byte digest under the caller's Bitcoin key.
+  // 
+  // # Details
+  // This is the Bitcoin counterpart of `eth_sign_prehash`: it signs an arbitrary hash with the
+  // caller's BTC key (schema `Btc`), so the signature verifies against the caller's P2WPKH address.
+  // Unlike `btc_caller_sign`, which builds and signs a transaction from supplied UTXOs, this signs
+  // any digest, which is what arbitrary message / PSBT signing (e.g. WalletConnect `signMessage` /
+  // `signPsbt`) requires. `generic_sign_with_ecdsa` cannot serve this: it derives a different
+  // (schema `Generic`) key whose signatures do not match the BTC address.
+  // 
+  // - Signs the message hash with `management_canister::ecdsa::sign_with_ecdsa(..)`
+  // - Costs: See [Fees for the t-ECDSA production key](https://internetcomputer.org/docs/current/references/t-sigs-how-it-works#fees-for-the-t-ecdsa-production-key)
+  // 
+  // Returns the raw 64-byte ECDSA signature (`r || s`) as hex; the caller recovers the recovery id
+  // from the known public key.
+  // 
+  // # Panics
+  // - If the caller is the anonymous user.
+  btc_sign_prehash : (BtcSignPrehashRequest, opt PaymentType) -> (Result_4);
   // Show the canister configuration.
   config : () -> (Config) query;
   // Returns the Ethereum address of a specified user.
@@ -412,7 +450,7 @@ service : (Arg) -> {
   // 
   // # Panics
   // - If the caller is the anonymous user.
-  eth_address : (EthAddressRequest, opt PaymentType) -> (Result_4);
+  eth_address : (EthAddressRequest, opt PaymentType) -> (Result_5);
   // Returns the Ethereum address of the caller.
   // 
   // # Details
@@ -423,7 +461,7 @@ service : (Arg) -> {
   // 
   // # Panics
   // - If the caller is the anonymous user.
-  eth_address_of_caller : (opt PaymentType) -> (Result_4);
+  eth_address_of_caller : (opt PaymentType) -> (Result_5);
   // Computes an Ethereum signature for a hex-encoded message according to [EIP-191](https://eips.ethereum.org/EIPS/eip-191).
   // 
   // # Details
@@ -438,7 +476,7 @@ service : (Arg) -> {
   // 
   // # Panics
   // - If the caller is the anonymous user.
-  eth_personal_sign : (EthPersonalSignRequest, opt PaymentType) -> (Result_5);
+  eth_personal_sign : (EthPersonalSignRequest, opt PaymentType) -> (Result_6);
   // Computes an Ethereum signature for a precomputed hash.
   // 
   // # Details
@@ -452,7 +490,7 @@ service : (Arg) -> {
   // 
   // # Panics
   // - If the caller is the anonymous user.
-  eth_sign_prehash : (EthSignPrehashRequest, opt PaymentType) -> (Result_6);
+  eth_sign_prehash : (EthSignPrehashRequest, opt PaymentType) -> (Result_7);
   // Computes an Ethereum signature for an [EIP-1559](https://eips.ethereum.org/EIPS/eip-1559) transaction.
   // 
   // # Details
@@ -468,7 +506,7 @@ service : (Arg) -> {
   // # Panics
   // - If the caller is the anonymous user.
   eth_sign_transaction : (EthSignTransactionRequest, opt PaymentType) -> (
-      Result_6,
+      Result_7,
     );
   // Returns the generic ECDSA public key of the caller.
   // 
@@ -485,7 +523,7 @@ service : (Arg) -> {
   // # Panics
   // - If the caller is the anonymous user.
   generic_caller_ecdsa_public_key : (EcdsaPublicKeyArgs, opt PaymentType) -> (
-      Result_7,
+      Result_8,
     );
   // Signs a message using the caller's ECDSA key.
   // 
@@ -501,7 +539,7 @@ service : (Arg) -> {
   // 
   // # Panics
   // - If the caller is the anonymous user.
-  generic_sign_with_ecdsa : (opt PaymentType, SignWithEcdsaArgs) -> (Result_8);
+  generic_sign_with_ecdsa : (opt PaymentType, SignWithEcdsaArgs) -> (Result_9);
   // API method to get cycle balance and burn rate.
   get_canister_status : () -> (CanisterStatusResultV2);
   // Processes external HTTP requests.
@@ -538,7 +576,7 @@ service : (Arg) -> {
   // 
   // # Panics
   // - If the caller is the anonymous user.
-  schnorr_public_key : (SchnorrPublicKeyArgs, opt PaymentType) -> (Result_9);
+  schnorr_public_key : (SchnorrPublicKeyArgs, opt PaymentType) -> (Result_10);
   // Signs a message using the caller's Schnorr key.
   // 
   // Note: This is an exact dual of the canister [`sign_with_schnorr`](https://internetcomputer.org/docs/current/references/ic-interface-spec/#ic-sign_with_schnorr) method.  The argument and response types are also the same.
@@ -571,5 +609,5 @@ service : (Arg) -> {
   // 
   // # Panics
   // - If the caller is the anonymous user.
-  schnorr_sign : (SignWithSchnorrArgs, opt PaymentType) -> (Result_10);
+  schnorr_sign : (SignWithSchnorrArgs, opt PaymentType) -> (Result_11);
 }

--- a/src/signer/canister/signer.did
+++ b/src/signer/canister/signer.did
@@ -18,7 +18,8 @@ type BtcSignPrehashRequest = record {
 };
 type BtcSignPrehashResponse = record {
   // Hex-encoded 64-byte ECDSA signature (`r || s`), as returned by the management canister.
-  // The caller recovers the recovery id (and any encoding it needs) from the known public key.
+  // The caller recovers the recovery id (and any encoding it needs) from the known public
+  // key.
   signature : text;
 };
 type BtcTxOutput = record { destination_address : text; sent_satoshis : nat64 };
@@ -423,7 +424,7 @@ service : (Arg) -> {
   // This is the Bitcoin counterpart of `eth_sign_prehash`: it signs an arbitrary hash with the
   // caller's BTC key (schema `Btc`), so the signature verifies against the caller's P2WPKH address.
   // Unlike `btc_caller_sign`, which builds and signs a transaction from supplied UTXOs, this signs
-  // any digest, which is what arbitrary message / PSBT signing (e.g. WalletConnect `signMessage` /
+  // any digest, which is what arbitrary message / PSBT signing (e.g. `WalletConnect` `signMessage` /
   // `signPsbt`) requires. `generic_sign_with_ecdsa` cannot serve this: it derives a different
   // (schema `Generic`) key whose signatures do not match the BTC address.
   // 

--- a/src/signer/canister/signer.did
+++ b/src/signer/canister/signer.did
@@ -7,6 +7,8 @@ type Bip341 = record {
 };
 type BitcoinAddressType = variant { P2WPKH };
 type BtcSignPrehashError = variant {
+  // The supplied hash was not valid hex or was not a 32-byte digest.
+  InvalidHash : record { msg : text };
   // An inter-canister call error from the threshold signature API.
   SigningError : text;
   // Payment failed.

--- a/src/signer/canister/src/lib.rs
+++ b/src/signer/canister/src/lib.rs
@@ -596,6 +596,22 @@ pub async fn btc_sign_prehash(
     req: BtcSignPrehashRequest,
     payment: Option<PaymentType>,
 ) -> Result<BtcSignPrehashResponse, BtcSignPrehashError> {
+    // Validate the input before charging: a malformed hash must return the typed error (not trap)
+    // and must not deduct payment from the caller.
+    let message_hash = hex::decode(req.hash.trim_start_matches("0x")).map_err(|e| {
+        BtcSignPrehashError::InvalidHash {
+            msg: format!("failed to decode hex: {e}"),
+        }
+    })?;
+    if message_hash.len() != 32 {
+        return Err(BtcSignPrehashError::InvalidHash {
+            msg: format!(
+                "expected a 32-byte digest, got {} bytes",
+                message_hash.len()
+            ),
+        });
+    }
+
     PAYMENT_GUARD
         .deduct(
             payment.unwrap_or(PaymentType::AttachedCycles),
@@ -603,7 +619,6 @@ pub async fn btc_sign_prehash(
         )
         .await?;
 
-    let message_hash = convert::decode_hex(&req.hash).to_vec();
     let signature = bitcoin_utils::sign_prehash(&msg_caller(), message_hash).await?;
 
     Ok(BtcSignPrehashResponse {

--- a/src/signer/canister/src/lib.rs
+++ b/src/signer/canister/src/lib.rs
@@ -11,9 +11,10 @@ use ic_chain_fusion_signer_api::{
     std_canister_status,
     types::{
         bitcoin::{
-            BitcoinAddressType, GetAddressError, GetAddressRequest, GetAddressResponse,
-            GetBalanceError, GetBalanceRequest, GetBalanceResponse, SendBtcError, SendBtcRequest,
-            SendBtcResponse, SignBtcResponse,
+            BitcoinAddressType, BtcSignPrehashError, BtcSignPrehashRequest, BtcSignPrehashResponse,
+            GetAddressError, GetAddressRequest, GetAddressResponse, GetBalanceError,
+            GetBalanceRequest, GetBalanceResponse, SendBtcError, SendBtcRequest, SendBtcResponse,
+            SignBtcResponse,
         },
         eth::{
             EthPersonalSignError, EthPersonalSignRequest, EthPersonalSignResponse,
@@ -570,6 +571,44 @@ pub async fn btc_caller_sign(
             })
         }
     }
+}
+
+/// Signs a precomputed 32-byte digest under the caller's Bitcoin key.
+///
+/// # Details
+/// This is the Bitcoin counterpart of `eth_sign_prehash`: it signs an arbitrary hash with the
+/// caller's BTC key (schema `Btc`), so the signature verifies against the caller's P2WPKH address.
+/// Unlike `btc_caller_sign`, which builds and signs a transaction from supplied UTXOs, this signs
+/// any digest, which is what arbitrary message / PSBT signing (e.g. `WalletConnect` `signMessage` /
+/// `signPsbt`) requires. `generic_sign_with_ecdsa` cannot serve this: it derives a different
+/// (schema `Generic`) key whose signatures do not match the BTC address.
+///
+/// - Signs the message hash with `management_canister::ecdsa::sign_with_ecdsa(..)`
+///   - Costs: See [Fees for the t-ECDSA production key](https://internetcomputer.org/docs/current/references/t-sigs-how-it-works#fees-for-the-t-ecdsa-production-key)
+///
+/// Returns the raw 64-byte ECDSA signature (`r || s`) as hex; the caller recovers the recovery id
+/// from the known public key.
+///
+/// # Panics
+/// - If the caller is the anonymous user.
+#[update(guard = "caller_is_not_anonymous")]
+pub async fn btc_sign_prehash(
+    req: BtcSignPrehashRequest,
+    payment: Option<PaymentType>,
+) -> Result<BtcSignPrehashResponse, BtcSignPrehashError> {
+    PAYMENT_GUARD
+        .deduct(
+            payment.unwrap_or(PaymentType::AttachedCycles),
+            SignerMethods::BtcSignPrehash.fee(),
+        )
+        .await?;
+
+    let message_hash = convert::decode_hex(&req.hash).to_vec();
+    let signature = bitcoin_utils::sign_prehash(&msg_caller(), message_hash).await?;
+
+    Ok(BtcSignPrehashResponse {
+        signature: hex::encode(signature),
+    })
 }
 
 /// Creates, signs and sends a BTC transaction from the caller's address.

--- a/src/signer/canister/src/sign/bitcoin/bitcoin_utils.rs
+++ b/src/signer/canister/src/sign/bitcoin/bitcoin_utils.rs
@@ -41,6 +41,12 @@ pub fn transform_network(network: BitcoinNetwork) -> Network {
 /// (e.g. `WalletConnect` `signMessage` / `signPsbt`) needs and `generic_sign_with_ecdsa` cannot
 /// provide, as it derives a different (schema `Generic`) key.
 pub async fn sign_prehash(principal: &Principal, message_hash: Vec<u8>) -> Result<Vec<u8>, String> {
+    if message_hash.len() != 32 {
+        return Err(format!(
+            "expected a 32-byte digest, got {} bytes",
+            message_hash.len()
+        ));
+    }
     ecdsa_api::get_ecdsa_signature(Schema::Btc.derivation_path(principal), message_hash).await
 }
 

--- a/src/signer/canister/src/sign/bitcoin/bitcoin_utils.rs
+++ b/src/signer/canister/src/sign/bitcoin/bitcoin_utils.rs
@@ -4,7 +4,7 @@ use candid::Principal;
 use ic_cdk_bitcoin_canister::Network as BitcoinNetwork;
 use ic_cdk_management_canister::{ecdsa_public_key, EcdsaCurve, EcdsaKeyId, EcdsaPublicKeyArgs};
 
-use crate::{derivation_path::Schema, state::read_config};
+use crate::{derivation_path::Schema, sign::ecdsa_api, state::read_config};
 
 /// Computes the public key of the specified principal.
 async fn ecdsa_pubkey_of(principal: &Principal) -> Result<Vec<u8>, String> {
@@ -31,6 +31,17 @@ pub fn transform_network(network: BitcoinNetwork) -> Network {
         BitcoinNetwork::Testnet => Network::Testnet,
         BitcoinNetwork::Regtest => Network::Regtest,
     }
+}
+
+/// Signs a precomputed 32-byte digest under the caller's Bitcoin key (schema `Btc`).
+///
+/// Returns the raw 64-byte ECDSA signature (`r || s`). Unlike `btc_caller_sign`, which builds and
+/// signs a transaction from supplied UTXOs, this signs an arbitrary digest, so the signature
+/// verifies against the caller's P2WPKH address. This is what arbitrary message / PSBT signing
+/// (e.g. `WalletConnect` `signMessage` / `signPsbt`) needs and `generic_sign_with_ecdsa` cannot
+/// provide, as it derives a different (schema `Generic`) key.
+pub async fn sign_prehash(principal: &Principal, message_hash: Vec<u8>) -> Result<Vec<u8>, String> {
+    ecdsa_api::get_ecdsa_signature(Schema::Btc.derivation_path(principal), message_hash).await
 }
 
 /// Converts a public key to a P2PKH address.

--- a/src/signer/canister/tests/it/bitcoin.rs
+++ b/src/signer/canister/tests/it/bitcoin.rs
@@ -5,9 +5,10 @@ use crate::{
     canister::{
         cycles_ledger::{self, ApproveArgs},
         signer::{
-            BitcoinAddressType, BtcTxOutput, GetAddressError, GetAddressRequest,
-            GetAddressResponse, GetBalanceRequest, GetBalanceResponse, Network, OutPoint,
-            PaymentType, SendBtcError, SendBtcRequest, SignBtcResponse, Utxo,
+            BitcoinAddressType, BtcSignPrehashError, BtcSignPrehashRequest, BtcSignPrehashResponse,
+            BtcTxOutput, GetAddressError, GetAddressRequest, GetAddressResponse, GetBalanceRequest,
+            GetBalanceResponse, Network, OutPoint, PaymentType, SendBtcError, SendBtcRequest,
+            SignBtcResponse, Utxo,
         },
     },
     utils::{
@@ -295,5 +296,85 @@ mod caller_sign {
         assert!(!response.signed_transaction_hex.is_empty());
         assert!(!response.txid.is_empty());
         assert!(hex::decode(&response.signed_transaction_hex).is_ok());
+    }
+}
+
+mod sign_prehash {
+    use super::*;
+
+    // An arbitrary 32-byte digest (hex), as `btc_sign_prehash` expects.
+    const PREHASH_HEX: &str = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+
+    /// A standard btc_sign_prehash() call, including payment.
+    fn paid_sign_prehash(
+        test_env: &TestSetup,
+        caller: Principal,
+        request: &BtcSignPrehashRequest,
+    ) -> Result<Result<BtcSignPrehashResponse, BtcSignPrehashError>, String> {
+        let payment_type = PaymentType::CallerPaysIcrc2Cycles;
+        let payment_recipient = cycles_ledger::Account {
+            owner: test_env.signer.canister_id(),
+            subaccount: None,
+        };
+        let amount: u128 = SignerMethods::BtcSignPrehash.fee() + LEDGER_FEE;
+        test_env
+            .ledger
+            .icrc2_approve(caller, &ApproveArgs::new(payment_recipient, amount.into()))
+            .expect("Failed to call ledger canister")
+            .expect("Failed to approve payment");
+
+        test_env
+            .signer
+            .btc_sign_prehash(caller, request, &Some(payment_type))
+    }
+
+    #[test]
+    fn can_btc_sign_prehash() {
+        let test_env = TestSetup::default();
+
+        let request = BtcSignPrehashRequest {
+            hash: PREHASH_HEX.to_string(),
+        };
+        let response = paid_sign_prehash(&test_env, test_env.user, &request)
+            .expect("Failed to reach signer canister")
+            .expect("Failed to sign");
+
+        // Raw 64-byte `r || s` ECDSA signature => 128 hex chars. The recovery id is left to the
+        // caller, who recovers it against the BTC public key (the key match is what makes this
+        // usable for arbitrary message / PSBT signing).
+        assert_eq!(response.signature.len(), 128);
+        assert!(hex::decode(&response.signature).is_ok());
+    }
+
+    #[test]
+    fn cannot_btc_sign_prehash_if_hash_is_not_hex() {
+        let test_env = TestSetup::default();
+
+        let request = BtcSignPrehashRequest {
+            hash: "not a hex string".to_string(),
+        };
+        let response = paid_sign_prehash(&test_env, test_env.user, &request);
+
+        assert!(response.is_err());
+        assert!(response.unwrap_err().contains("failed to decode hex"));
+    }
+
+    #[test]
+    fn test_anonymous_cannot_btc_sign_prehash() {
+        let test_env = TestSetup::default();
+
+        let request = BtcSignPrehashRequest {
+            hash: PREHASH_HEX.to_string(),
+        };
+        let result = test_env.signer.btc_sign_prehash(
+            Principal::anonymous(),
+            &request,
+            &Some(PaymentType::CallerPaysIcrc2Cycles),
+        );
+
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .contains("Anonymous caller not authorized"));
     }
 }

--- a/src/signer/canister/tests/it/bitcoin.rs
+++ b/src/signer/canister/tests/it/bitcoin.rs
@@ -353,10 +353,38 @@ mod sign_prehash {
         let request = BtcSignPrehashRequest {
             hash: "not a hex string".to_string(),
         };
-        let response = paid_sign_prehash(&test_env, test_env.user, &request);
+        let response = paid_sign_prehash(&test_env, test_env.user, &request)
+            .expect("Failed to reach signer canister");
 
-        assert!(response.is_err());
-        assert!(response.unwrap_err().contains("failed to decode hex"));
+        // Malformed input must surface as the typed error (no trap).
+        match response {
+            Err(BtcSignPrehashError::InvalidHash { msg }) => {
+                assert!(
+                    msg.contains("failed to decode hex"),
+                    "unexpected msg: {msg}"
+                );
+            }
+            other => panic!("expected InvalidHash error, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn cannot_btc_sign_prehash_if_hash_is_not_32_bytes() {
+        let test_env = TestSetup::default();
+
+        // Valid hex, but only 31 bytes.
+        let request = BtcSignPrehashRequest {
+            hash: "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcd".to_string(),
+        };
+        let response = paid_sign_prehash(&test_env, test_env.user, &request)
+            .expect("Failed to reach signer canister");
+
+        match response {
+            Err(BtcSignPrehashError::InvalidHash { msg }) => {
+                assert!(msg.contains("32-byte digest"), "unexpected msg: {msg}");
+            }
+            other => panic!("expected InvalidHash error, got {other:?}"),
+        }
     }
 
     #[test]

--- a/src/signer/canister/tests/it/canister/signer.rs
+++ b/src/signer/canister/tests/it/canister/signer.rs
@@ -242,7 +242,8 @@ pub(crate) struct BtcSignPrehashRequest {
 #[derive(CandidType, Deserialize, Debug, Eq, PartialEq, Clone)]
 pub(crate) struct BtcSignPrehashResponse {
     /// Hex-encoded 64-byte ECDSA signature (`r || s`), as returned by the management canister.
-    /// The caller recovers the recovery id (and any encoding it needs) from the known public key.
+    /// The caller recovers the recovery id (and any encoding it needs) from the known public
+    /// key.
     pub(crate) signature: String,
 }
 #[derive(CandidType, Deserialize, Debug, Eq, PartialEq, Clone)]

--- a/src/signer/canister/tests/it/canister/signer.rs
+++ b/src/signer/canister/tests/it/canister/signer.rs
@@ -248,6 +248,8 @@ pub(crate) struct BtcSignPrehashResponse {
 }
 #[derive(CandidType, Deserialize, Debug, Eq, PartialEq, Clone)]
 pub(crate) enum BtcSignPrehashError {
+    /// The supplied hash was not valid hex or was not a 32-byte digest.
+    InvalidHash { msg: String },
     /// An inter-canister call error from the threshold signature API.
     SigningError(String),
     /// Payment failed.

--- a/src/signer/canister/tests/it/canister/signer.rs
+++ b/src/signer/canister/tests/it/canister/signer.rs
@@ -235,6 +235,25 @@ pub(crate) struct SignBtcResponse {
 }
 pub(crate) type Result3 = std::result::Result<SignBtcResponse, SendBtcError>;
 #[derive(CandidType, Deserialize, Debug, Eq, PartialEq, Clone)]
+pub(crate) struct BtcSignPrehashRequest {
+    /// Hex-encoded 32-byte digest to sign under the caller's Bitcoin key.
+    pub(crate) hash: String,
+}
+#[derive(CandidType, Deserialize, Debug, Eq, PartialEq, Clone)]
+pub(crate) struct BtcSignPrehashResponse {
+    /// Hex-encoded 64-byte ECDSA signature (`r || s`), as returned by the management canister.
+    /// The caller recovers the recovery id (and any encoding it needs) from the known public key.
+    pub(crate) signature: String,
+}
+#[derive(CandidType, Deserialize, Debug, Eq, PartialEq, Clone)]
+pub(crate) enum BtcSignPrehashError {
+    /// An inter-canister call error from the threshold signature API.
+    SigningError(String),
+    /// Payment failed.
+    PaymentError(PaymentError),
+}
+pub(crate) type Result4 = std::result::Result<BtcSignPrehashResponse, BtcSignPrehashError>;
+#[derive(CandidType, Deserialize, Debug, Eq, PartialEq, Clone)]
 pub(crate) struct Config {
     pub(crate) ecdsa_key_name: String,
     /// Root of trust for checking canister signatures.
@@ -258,7 +277,7 @@ pub(crate) enum EthAddressError {
     /// Payment failed.
     PaymentError(PaymentError),
 }
-pub(crate) type Result4 = std::result::Result<EthAddressResponse, EthAddressError>;
+pub(crate) type Result5 = std::result::Result<EthAddressResponse, EthAddressError>;
 #[derive(CandidType, Deserialize, Debug, Eq, PartialEq, Clone)]
 pub(crate) struct EthPersonalSignRequest {
     pub(crate) message: String,
@@ -267,7 +286,7 @@ pub(crate) struct EthPersonalSignRequest {
 pub(crate) struct EthPersonalSignResponse {
     pub(crate) signature: String,
 }
-pub(crate) type Result5 = std::result::Result<EthPersonalSignResponse, EthAddressError>;
+pub(crate) type Result6 = std::result::Result<EthPersonalSignResponse, EthAddressError>;
 #[derive(CandidType, Deserialize, Debug, Eq, PartialEq, Clone)]
 pub(crate) struct EthSignPrehashRequest {
     pub(crate) hash: String,
@@ -276,7 +295,7 @@ pub(crate) struct EthSignPrehashRequest {
 pub(crate) struct EthSignPrehashResponse {
     pub(crate) signature: String,
 }
-pub(crate) type Result6 = std::result::Result<EthSignPrehashResponse, EthAddressError>;
+pub(crate) type Result7 = std::result::Result<EthSignPrehashResponse, EthAddressError>;
 #[derive(CandidType, Deserialize, Debug, Eq, PartialEq, Clone)]
 pub(crate) struct EthSignTransactionRequest {
     pub(crate) to: String,
@@ -327,7 +346,7 @@ pub(crate) struct EcdsaPublicKeyResult {
     /// Can be used to deterministically derive child keys of the [`public_key`](Self::public_key).
     pub(crate) chain_code: serde_bytes::ByteBuf,
 }
-pub(crate) type Result7 = std::result::Result<(EcdsaPublicKeyResult,), EthAddressError>;
+pub(crate) type Result8 = std::result::Result<(EcdsaPublicKeyResult,), EthAddressError>;
 /// # Sign With ECDSA Args.
 ///
 /// Argument type of [`sign_with_ecdsa`](https://internetcomputer.org/docs/current/references/ic-interface-spec/#ic-sign_with_ecdsa).
@@ -348,7 +367,7 @@ pub(crate) struct SignWithEcdsaResult {
     /// Encoded as the concatenation of the SEC1 encodings of the two values `r` and `s`.
     pub(crate) signature: serde_bytes::ByteBuf,
 }
-pub(crate) type Result8 = std::result::Result<(SignWithEcdsaResult,), EthAddressError>;
+pub(crate) type Result9 = std::result::Result<(SignWithEcdsaResult,), EthAddressError>;
 /// # Canister Status Type
 ///
 /// Status of a canister.
@@ -439,7 +458,7 @@ pub(crate) struct SchnorrPublicKeyArgs {
     /// A vector of variable length byte strings.
     pub(crate) derivation_path: Vec<serde_bytes::ByteBuf>,
 }
-pub(crate) type Result9 = std::result::Result<(EcdsaPublicKeyResult,), EthAddressError>;
+pub(crate) type Result10 = std::result::Result<(EcdsaPublicKeyResult,), EthAddressError>;
 /// # Bip341 variant of Schnorr Aux.
 #[derive(CandidType, Deserialize, Debug, Eq, PartialEq, Clone)]
 pub(crate) struct Bip341 {
@@ -466,7 +485,7 @@ pub(crate) struct SignWithSchnorrArgs {
     /// Message to be signed.
     pub(crate) message: serde_bytes::ByteBuf,
 }
-pub(crate) type Result10 = std::result::Result<(SignWithEcdsaResult,), EthAddressError>;
+pub(crate) type Result11 = std::result::Result<(SignWithEcdsaResult,), EthAddressError>;
 
 pub struct SignerPic {
     pub pic: Arc<PocketIc>,
@@ -526,6 +545,14 @@ impl SignerPic {
     ) -> Result<Result3, String> {
         self.update(caller, "btc_caller_sign", (arg0, arg1))
     }
+    pub fn btc_sign_prehash(
+        &self,
+        caller: Principal,
+        arg0: &BtcSignPrehashRequest,
+        arg1: &Option<PaymentType>,
+    ) -> Result<Result4, String> {
+        self.update(caller, "btc_sign_prehash", (arg0, arg1))
+    }
     pub fn config(&self, caller: Principal) -> Result<Config, String> {
         self.update(caller, "config", ())
     }
@@ -534,14 +561,14 @@ impl SignerPic {
         caller: Principal,
         arg0: &EthAddressRequest,
         arg1: &Option<PaymentType>,
-    ) -> Result<Result4, String> {
+    ) -> Result<Result5, String> {
         self.update(caller, "eth_address", (arg0, arg1))
     }
     pub fn eth_address_of_caller(
         &self,
         caller: Principal,
         arg0: &Option<PaymentType>,
-    ) -> Result<Result4, String> {
+    ) -> Result<Result5, String> {
         self.update(caller, "eth_address_of_caller", (arg0,))
     }
     pub fn eth_personal_sign(
@@ -549,7 +576,7 @@ impl SignerPic {
         caller: Principal,
         arg0: &EthPersonalSignRequest,
         arg1: &Option<PaymentType>,
-    ) -> Result<Result5, String> {
+    ) -> Result<Result6, String> {
         self.update(caller, "eth_personal_sign", (arg0, arg1))
     }
     pub fn eth_sign_prehash(
@@ -557,7 +584,7 @@ impl SignerPic {
         caller: Principal,
         arg0: &EthSignPrehashRequest,
         arg1: &Option<PaymentType>,
-    ) -> Result<Result6, String> {
+    ) -> Result<Result7, String> {
         self.update(caller, "eth_sign_prehash", (arg0, arg1))
     }
     pub fn eth_sign_transaction(
@@ -565,7 +592,7 @@ impl SignerPic {
         caller: Principal,
         arg0: &EthSignTransactionRequest,
         arg1: &Option<PaymentType>,
-    ) -> Result<Result6, String> {
+    ) -> Result<Result7, String> {
         self.update(caller, "eth_sign_transaction", (arg0, arg1))
     }
     pub fn generic_caller_ecdsa_public_key(
@@ -573,7 +600,7 @@ impl SignerPic {
         caller: Principal,
         arg0: &EcdsaPublicKeyArgs,
         arg1: &Option<PaymentType>,
-    ) -> Result<Result7, String> {
+    ) -> Result<Result8, String> {
         self.update(caller, "generic_caller_ecdsa_public_key", (arg0, arg1))
     }
     pub fn generic_sign_with_ecdsa(
@@ -581,7 +608,7 @@ impl SignerPic {
         caller: Principal,
         arg0: &Option<PaymentType>,
         arg1: &SignWithEcdsaArgs,
-    ) -> Result<Result8, String> {
+    ) -> Result<Result9, String> {
         self.update(caller, "generic_sign_with_ecdsa", (arg0, arg1))
     }
     pub fn get_canister_status(&self, caller: Principal) -> Result<CanisterStatusResultV2, String> {
@@ -599,7 +626,7 @@ impl SignerPic {
         caller: Principal,
         arg0: &SchnorrPublicKeyArgs,
         arg1: &Option<PaymentType>,
-    ) -> Result<Result9, String> {
+    ) -> Result<Result10, String> {
         self.update(caller, "schnorr_public_key", (arg0, arg1))
     }
     pub fn schnorr_sign(
@@ -607,7 +634,7 @@ impl SignerPic {
         caller: Principal,
         arg0: &SignWithSchnorrArgs,
         arg1: &Option<PaymentType>,
-    ) -> Result<Result10, String> {
+    ) -> Result<Result11, String> {
         self.update(caller, "schnorr_sign", (arg0, arg1))
     }
 }


### PR DESCRIPTION
# Motivation

The signer can sign an arbitrary message hash under the Ethereum key (`eth_sign_prehash`) but has no equivalent for the Bitcoin key. The two existing BTC signing methods, `btc_caller_send`/`btc_caller_sign`, only sign a transaction the signer builds itself from supplied UTXOs — they cannot sign a standalone message or a caller-supplied PSBT.

`generic_sign_with_ecdsa` does sign arbitrary digests, but under the generic key (`Schema::Generic`, `0xff`), whose derived key does not match a caller's P2WPKH address (`Schema::Btc`, `0x00`). A signature obtained that way fails to verify against the BTC address, so it is unusable for Bitcoin message/PSBT signing.

This blocks integrations that need to sign arbitrary Bitcoin data with the caller's real address — e.g. WalletConnect `signMessage` and `signPsbt`.

# Changes

- Add `btc_sign_prehash(BtcSignPrehashRequest, opt PaymentType)`, the BTC counterpart of `eth_sign_prehash`. It signs a precomputed 32-byte digest under `Schema::Btc` and returns the raw 64-byte `r || s` signature (hex); the caller recovers the recovery id from the known public key.
- New API types `BtcSignPrehashRequest` / `BtcSignPrehashResponse` / `BtcSignPrehashError` and a `SignerMethods::BtcSignPrehash` fee variant (flat `37 B`, one `sign_with_ecdsa`, no transaction building).
- Regenerated candid (`signer.did`) and pocket-ic test bindings.

Additive interface change.

# Tests

- Added integration tests: happy path (well-formed 64-byte signature), invalid-hex rejection, and anonymous-caller rejection.
- `cargo build --target wasm32-unknown-unknown --release`, clippy (pedantic, `-D warnings`), nightly `cargo fmt`, and the API-crate unit tests all pass. The pocket-ic integration tests run in CI.