### PR TITLE
chore(release): Bump version to 0.5.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -787,7 +787,7 @@ dependencies = [
 
 [[package]]
 name = "example_backend"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "candid",
  "ic-cdk 0.20.2",
@@ -1343,7 +1343,7 @@ dependencies = [
 
 [[package]]
 name = "ic-chain-fusion-signer-api"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "candid",
  "ic-canister-sig-creation",
@@ -2840,7 +2840,7 @@ dependencies = [
 
 [[package]]
 name = "signer"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "assert_matches",
  "bitcoin",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.5.0"
+version = "0.5.1"
 
 [workspace.dependencies]
 assert_matches = "1.5.0"


### PR DESCRIPTION
# Motivation

Cut the `0.5.1` release. Notable changes since `v0.5.0`:

- **`btc_sign_prehash` (#545)** — sign an arbitrary digest under the BTC key; the additive primitive enabling the WalletConnect flow.
- **Upgrade-proposal tooling (#539)** — NNS upgrade proposals now submit `(variant { Upgrade })`, preserving the canister's existing config instead of re-applying the `Init` args.
- Plus dependency updates.

Additive/fixes only, so a **patch** bump.

# Changes

- Bump the workspace version `0.5.0` → `0.5.1` in the root `Cargo.toml` (inherited by `signer`, `ic-chain-fusion-signer-api`, `example_backend`) and regenerate `Cargo.lock`.

# Tests

N/A — version-only bump.
