### PR TITLE
chore(deps): Bump quinn-proto to 0.11.15 for RUSTSEC-2026-0185

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2206,9 +2206,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "bytes",
  "getrandom 0.3.4",


### PR DESCRIPTION
# Motivation

CI `Rust package audit` fails on `RUSTSEC-2026-0185` — *Remote memory exhaustion in `quinn-proto` from unbounded out-of-order stream reassembly* (severity 7.5 high). It affects `quinn-proto 0.11.14`, currently in `Cargo.lock`.

The crate is a **dev-dependency only** (`quinn-proto ← quinn ← reqwest ← pocket-ic ← signer`), so it is test tooling and is **not** part of the shipped canister Wasm — but it still red-lights the audit gate on `main` and every PR.

Fix per the advisory: upgrade to `>= 0.11.15`.

# Changes

- `cargo update -p quinn-proto --precise 0.11.15` — a one-line `Cargo.lock` change (`0.11.14` → `0.11.15`), no manifest/source changes.

# Tests

N/A — lockfile-only. CI `Rust package audit` should go green; the remaining audit entries are pre-existing allowed warnings.
