### PR TITLE
fix(ci): Avoid SIGPIPE in commit.txt build step

### DIFF
--- a/.github/actions/build/action.yaml
+++ b/.github/actions/build/action.yaml
@@ -28,7 +28,9 @@ runs:
       shell: bash
       run: |
         set -euxo pipefail
-        git log | head -n1 > out/commit.txt
+        # `git log | head -n1` makes git receive SIGPIPE under `pipefail` (exit 141);
+        # `-1 --format=%H` also yields the bare commit hash RELEASE.md's checks expect.
+        git log -1 --format=%H > out/commit.txt
     - name: Install build tools
       shell: bash
       run: scripts/setup cargo-binstall ic-wasm

--- a/.github/actions/build/action.yaml
+++ b/.github/actions/build/action.yaml
@@ -28,7 +28,6 @@ runs:
       shell: bash
       run: |
         set -euxo pipefail
-        # Not `git log | head -n1`: that SIGPIPEs git under pipefail (exit 141).
         git log -1 --format=%H > out/commit.txt
     - name: Install build tools
       shell: bash

--- a/.github/actions/build/action.yaml
+++ b/.github/actions/build/action.yaml
@@ -28,8 +28,7 @@ runs:
       shell: bash
       run: |
         set -euxo pipefail
-        # `git log | head -n1` makes git receive SIGPIPE under `pipefail` (exit 141);
-        # `-1 --format=%H` also yields the bare commit hash RELEASE.md's checks expect.
+        # Not `git log | head -n1`: that SIGPIPEs git under pipefail (exit 141).
         git log -1 --format=%H > out/commit.txt
     - name: Install build tools
       shell: bash


### PR DESCRIPTION
# Motivation

The `prepare-proposal`/Release build fails at *"Record the git commit"* with exit 141: under `pipefail`, `head -n1` closes the pipe and `git log` dies on SIGPIPE. This is one of the blockers for the automated release chain (RELEASE.md → Automation).

# Changes

- `.github/actions/build/action.yaml`: `git log | head -n1` → `git log -1 --format=%H`. No pipe (no SIGPIPE), and it writes the bare commit hash that RELEASE.md step 3 expects.

# Tests

- `scripts/proposal-assets.test` checksums a historical published `commit.txt`, so it's unaffected by this future-build change.
