### PR TITLE
chore(deps): Bump quinn-proto to 0.11.15 for RUSTSEC-2026-0185

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2232,9 +2232,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "bytes",
  "getrandom 0.3.4",


### PR DESCRIPTION
# Motivation

CI `Rust package audit` fails on the one vulnerability cargo-audit flags: `RUSTSEC-2026-0185` — *Remote memory exhaustion in `quinn-proto` from unbounded out-of-order stream reassembly* (severity 7.5 high), affecting `quinn-proto 0.11.14`.

It's a dev-dependency (`quinn-proto ← quinn ← reqwest ← pocket-ic ← signer`) so it's test tooling, not in the shipped canister Wasm — but it red-lights the audit gate. Note it does **not** appear in GitHub's Security tab: its GHSA alias (`GHSA-4w2j-m93h-cj5j`) isn't published in GitHub's Advisory Database yet, and Dependabot only alerts on GHSA; cargo-audit reads RustSec directly, so CI catches it first.

Fix per the advisory: upgrade to `>= 0.11.15`.

# Changes

- `cargo update -p quinn-proto --precise 0.11.15` — two-line `Cargo.lock` change (version + checksum).

# Scope

This is the only cargo-audit **vulnerability**. The remaining 5 entries are `allowed` warnings that do not fail CI and have no fix to bump to: `anyhow`/`rand` (unsound, no patched release) and `backoff`/`instant`/`paste` (unmaintained, no successor). They'd need upstream `pocket-ic`/`candid` changes or an `audit.toml` ignore, not a lockfile bump.

# Tests

- `cargo audit` locally: 0 vulnerabilities (down from 1), 5 allowed warnings — the `audit_pass` gate goes green.
