### PR TITLE
chore(ci): Add BOT_APPROVED_FILES so the release bot can bump the version

### DIFF
--- a/.github/repo_policies/BOT_APPROVED_FILES
+++ b/.github/repo_policies/BOT_APPROVED_FILES
@@ -1,0 +1,8 @@
+# List of approved files that can be changed by a bot via an automated PR
+# This is to increase security and prevent accidentally updating files that shouldn't be changed by a bot
+#
+# Only the version bump opened by the release automation (bump-version.yml, authored by
+# pr-automation-bot-public[bot]) is checked against this list; dependabot is exempt.
+
+Cargo.toml
+Cargo.lock

--- a/.github/repo_policies/BOT_APPROVED_FILES
+++ b/.github/repo_policies/BOT_APPROVED_FILES
@@ -1,8 +1,5 @@
 # List of approved files that can be changed by a bot via an automated PR
 # This is to increase security and prevent accidentally updating files that shouldn't be changed by a bot
-#
-# Only the version bump opened by the release automation (bump-version.yml, authored by
-# pr-automation-bot-public[bot]) is checked against this list; dependabot is exempt.
 
 Cargo.toml
 Cargo.lock


### PR DESCRIPTION
# Motivation

`check-repo-policies / Check Bot Policies` fails on #560 (the release PR opened by `bump-version`):

```
No config file found. Make sure you have a file saved at
.github/repo_policies/BOT_APPROVED_FILES in the default branch
```

The org-wide Bot Policies ruleset makes each repo declare which files a bot may touch, and this repo never had that config. It hasn't bitten us before because **dependabot is exempt** — the script skips it before loading the config. `bump-version` authors as `pr-automation-bot-public[bot]`, which isn't exempt, so it's the first bot here to reach the lookup.

# Changes

- Add `.github/repo_policies/BOT_APPROVED_FILES` listing `Cargo.toml` and `Cargo.lock` — exactly what `./scripts/version-bump` touches, and what #560 changes.

Kept minimal since the policy exists to constrain bots: `bump-version` is the only PR-opening workflow here. Dependabot's other paths are omitted because it never reaches this check.

# Tests

Ran the org script's own `fnmatch` logic against #560's changed files → both `Cargo.toml` and `Cargo.lock` match, PR would be ALLOWED.

Note: the config is read from the **default branch**, so this must merge before #560's check passes.
