### PR TITLE
fix(ci): Install the release wasm and keep staging's config on deploy

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -54,13 +54,21 @@ jobs:
         env:
           DFX_DEPLOY_KEY: ${{ secrets.DFX_DEPLOY_KEY_STAGING }}
       - name: Deploy signer to staging
-        # The build artifacts contain the init args for DFX_NETWORK=ic, which
-        # do not apply to staging. Pass an explicit Upgrade argument so that
-        # post_upgrade preserves the existing staging configuration instead of
-        # applying the ic init args.
-        run: dfx canister install signer --mode upgrade --upgrade-unchanged --argument '(variant { Upgrade })' --network staging --yes
+        # The artifacts carry the init args for DFX_NETWORK=ic (ecdsa_key_name = "key_1"),
+        # which must never be applied to staging. dfx.json points init_arg_file at
+        # out/signer.args.did and reads it in preference to --argument, so the file itself
+        # has to be neutralized: (null) => post_upgrade(None) => staging config preserved.
+        # The .dfx dir lets dfx run its Candid compat check instead of prompting.
+        run: |
+          printf '(null)\n' > out/signer.args.did
+          mkdir -p .dfx/staging/canisters/signer
+          dfx canister install signer --wasm out/signer.wasm.gz \
+            --mode upgrade --upgrade-unchanged --network staging --yes
       - name: Verify deployment
         run: |
           sha256sum out/signer.wasm.gz
           dfx canister info signer --network staging
           dfx canister metadata signer git:commit --network staging
+          # Fail loudly rather than leave staging silently pointed at the production key.
+          key="$(dfx canister call signer config --network staging | sed -n 's/.*ecdsa_key_name = "\([^"]*\)".*/\1/p')"
+          [ "$key" = "test_key_1" ] || { echo "ERROR: staging ecdsa_key_name is '$key', expected test_key_1"; exit 1; }


### PR DESCRIPTION
# Motivation

`Deploy to Staging` fired for `v0.5.1` (the first time the release chain reached it) and failed:

```
+ dfx canister install signer --mode upgrade --upgrade-unchanged --argument '(variant { Upgrade })' --network staging --yes
Error: Failed to install wasm module to canister 'signer'.
Caused by: The canister must be built before install. Please run `dfx build`.
```

Two separate bugs, and the first was hiding the second:

1. **The release wasm was never installed.** The job downloads the artifacts to `out/` but calls `dfx canister install` without `--wasm`, so dfx looks for its own build output and gives up.

2. **The install would have applied the production init args.** The artifacts include `out/signer.args.did`, which is built for `DFX_NETWORK=ic` and contains `ecdsa_key_name = "key_1"`. `dfx.json` sets `init_arg_file: out/signer.args.did` and dfx reads that file in preference to `--argument`, so the existing `--argument '(variant { Upgrade })'` guard does not take effect (this is the gotcha already documented in RELEASE.md step 5). Fixing only (1) would therefore have upgraded staging **and repointed it at the production key**.

Staging is currently still on `test_key_1` only because (1) aborted the install first.

# Changes

- Install the downloaded artifact explicitly: `dfx canister install signer --wasm out/signer.wasm.gz`.
- Neutralize the init args before installing — `printf '(null)\n' > out/signer.args.did` — so `post_upgrade(None)` preserves the existing staging config. This mirrors the by-hand path in RELEASE.md step 5, which is the proven one. The ineffective `--argument` flag is dropped.
- `mkdir -p .dfx/staging/canisters/signer` so dfx runs its Candid compat check instead of falling back to a prompt.
- Add a post-deploy assertion that `ecdsa_key_name` is still `test_key_1`, so a regression fails the job loudly instead of leaving staging silently pointed at the production key.

# Tests

- Verified the assertion's parsing against the live staging canister: it extracts `test_key_1` and passes.
- The same install sequence (neutralized args + `--wasm`) was used to deploy `main` to staging by hand earlier today; the module hash matched and `config` still reported `test_key_1`.
- Prettier clean.

Once merged, re-run `Deploy to Staging` (`workflow_dispatch`) or re-run the failed `v0.5.1` job to land the release on staging.
