### PR TITLE
fix(scripts): Do not echo the HSM PIN when proposing

### DIFF
--- a/scripts/propose
+++ b/scripts/propose
@@ -62,9 +62,11 @@ fi
 PEM_PATH="$HOME/.config/dfx/identity/${DFX_IDENTITY}/identity.pem"
 if [[ "${DFX_NETWORK:-}" =~ mainnet|ic ]] || [[ "${DFX_HSM_KEY_ID:-}" != "" ]]; then
   # Authenticate with an HSM
-  read -rp "HSM Pin: " DFX_HSM_PIN
+  read -rsp "HSM Pin: " DFX_HSM_PIN
+  echo >&2           # `read -s` suppresses the newline the user typed.
   export DFX_HSM_PIN # Needed for dfx canister id, for some strange reason.
   AUTH_ARGS=(--use-hsm --pin "$DFX_HSM_PIN" --key-id "${DFX_HSM_KEY_ID}" --slot 0)
+  AUTH_ARGS_REDACTED=(--use-hsm --pin "<redacted>" --key-id "${DFX_HSM_KEY_ID}" --slot 0)
 elif test -e "$PEM_PATH"; then
   # Authenticate with a pem file
   [[ "$(jq .encryption "$HOME/.config/dfx/identity/${DFX_IDENTITY}/identity.json")" == "null" ]] || {
@@ -72,6 +74,7 @@ elif test -e "$PEM_PATH"; then
     exit 1
   } >&2
   AUTH_ARGS=(--secret-key-pem "$PEM_PATH")
+  AUTH_ARGS_REDACTED=("${AUTH_ARGS[@]}")
 else
   {
     echo "ERROR: Please specify the HSM key ID (usually 01) or use a dfx identity with an unencrypted pem file."
@@ -129,12 +132,13 @@ test -e "${SUMMARY_FILE:-}" || {
 } >&2
 
 # Prepares the command
-set ic-admin "${AUTH_ARGS[@]}" --nns-url "$DFX_NNS_URL" propose-to-change-nns-canister --proposer "$DFX_NEURON_ID" --canister-id "$CANISTER_ID" --mode upgrade --wasm-module-path "$WASM" --summary-file "$SUMMARY_FILE" --wasm-module-sha256 "$WASM_SHA" --arg "$ARG_PATH" --arg-sha256 "$ARG_SHA"
+PROPOSAL_ARGS=(--nns-url "$DFX_NNS_URL" propose-to-change-nns-canister --proposer "$DFX_NEURON_ID" --canister-id "$CANISTER_ID" --mode upgrade --wasm-module-path "$WASM" --summary-file "$SUMMARY_FILE" --wasm-module-sha256 "$WASM_SHA" --arg "$ARG_PATH" --arg-sha256 "$ARG_SHA")
+set ic-admin "${AUTH_ARGS[@]}" "${PROPOSAL_ARGS[@]}"
 # ... just checking...
 echo
 echo PLEASE REVIEW THIS COMMAND:
 echo
-echo "${@}"
+echo "ic-admin ${AUTH_ARGS_REDACTED[*]} ${PROPOSAL_ARGS[*]}"
 echo
 
 read -rp "Execute? (y/N) " COMMAND_OK


### PR DESCRIPTION
# Motivation

`scripts/propose` read the HSM PIN with echo on, so it appeared on screen as it was typed. It then put the PIN into `AUTH_ARGS` and printed the whole command under `PLEASE REVIEW THIS COMMAND:`, so the block operators are told to read — and may paste or screenshot — contained `--pin <cleartext PIN>`.

# Changes

- `read -rsp` for the PIN, plus an `echo >&2` for the newline `-s` suppresses.
- Split the non-auth flags into `PROPOSAL_ARGS` and print `AUTH_ARGS_REDACTED` (`--pin <redacted>`) alongside them. The executed command is unchanged and still passes the real PIN to `ic-admin`; the pem branch prints its args verbatim.

# Tests

- `shfmt -i 2 -d scripts/propose`, `shellcheck -e SC1090 -e SC2119 -e SC1091 scripts/propose` and `./scripts/lint-sh` are clean.
- Replayed both auth branches in a standalone snippet under `set -euo pipefail`: the printed command hides the PIN and keeps every other flag (`--proposer`, `--canister-id`, `--mode upgrade`, `--wasm-module-sha256`, `--arg-sha256`, `--nns-url`), the executed command keeps the real PIN, and the pem branch (PIN unset) does not error.