### PR TITLE
fix(scripts): Explain how to verify the upgrade argument

### DIFF
--- a/scripts/proposal-template
+++ b/scripts/proposal-template
@@ -121,10 +121,15 @@ git checkout tags/$RELEASE_CANDIDATE_TAG
 ./scripts/docker-build
 \`\`\`
 
-This will generate these files:
-- out/signer.wasm.gz
-- out/signer.args.did
-- out/signer.args.bin
+The sha256 of the resulting \`out/signer.wasm.gz\` must equal the wasm hash above.
+
+That build also writes \`out/signer.args.did\` and \`out/signer.args.bin\`. Those are the **Init** arguments, used only when the canister is installed for the first time — they are **not** the argument of this proposal, and their hashes will not match it. This is an upgrade, so the argument is the network-independent \`(variant { Upgrade })\`, which preserves the canister's existing configuration. Reproduce it with:
+
+\`\`\`
+didc encode '(variant { Upgrade })' | xxd -r -p | sha256sum
+\`\`\`
+
+The result must equal the binary argument hash above.
 
 EOF
 
@@ -145,10 +150,13 @@ git checkout ${ROLLBACK_CHECKOUT}
 ./scripts/docker-build
 \`\`\`
 
-This will generate these files:
-- out/signer.wasm.gz
-- out/signer.args.did
-- out/signer.args.bin
+The sha256 of the resulting \`out/signer.wasm.gz\` must equal the wasm hash above.
+
+That build also writes \`out/signer.args.did\` and \`out/signer.args.bin\`. Those are the **Init** arguments, used only when the canister is installed for the first time — they are **not** the argument of this rollback. A rollback is an upgrade, so it uses the network-independent \`(variant { Upgrade })\`, which preserves the canister's existing configuration. Reproduce it with:
+
+\`\`\`
+didc encode '(variant { Upgrade })' | xxd -r -p | sha256sum
+\`\`\`
 
 EOF
 

--- a/scripts/proposal-template.test.proposal.txt
+++ b/scripts/proposal-template.test.proposal.txt
@@ -92,8 +92,13 @@ git checkout tags/v0.2.8
 ./scripts/docker-build
 ```
 
-This will generate these files:
-- out/signer.wasm.gz
-- out/signer.args.did
-- out/signer.args.bin
+The sha256 of the resulting `out/signer.wasm.gz` must equal the wasm hash above.
+
+That build also writes `out/signer.args.did` and `out/signer.args.bin`. Those are the **Init** arguments, used only when the canister is installed for the first time — they are **not** the argument of this proposal, and their hashes will not match it. This is an upgrade, so the argument is the network-independent `(variant { Upgrade })`, which preserves the canister's existing configuration. Reproduce it with:
+
+```
+didc encode '(variant { Upgrade })' | xxd -r -p | sha256sum
+```
+
+The result must equal the binary argument hash above.
 

--- a/scripts/proposal-template.test.rollback.txt
+++ b/scripts/proposal-template.test.rollback.txt
@@ -14,8 +14,11 @@ git checkout tags/v0.2.7
 ./scripts/docker-build
 ```
 
-This will generate these files:
-- out/signer.wasm.gz
-- out/signer.args.did
-- out/signer.args.bin
+The sha256 of the resulting `out/signer.wasm.gz` must equal the wasm hash above.
+
+That build also writes `out/signer.args.did` and `out/signer.args.bin`. Those are the **Init** arguments, used only when the canister is installed for the first time — they are **not** the argument of this rollback. A rollback is an upgrade, so it uses the network-independent `(variant { Upgrade })`, which preserves the canister's existing configuration. Reproduce it with:
+
+```
+didc encode '(variant { Upgrade })' | xxd -r -p | sha256sum
+```
 


### PR DESCRIPTION
# Motivation

A reviewer of proposal 142929 (Chain Fusion Signer v0.5.1) reported an argument mismatch. The proposal is correct — the runbook we generate for them is not.

`PROPOSAL.md`'s "Wasm Verification" section tells the reviewer to run `./scripts/docker-build` and then lists `out/signer.args.did` / `out/signer.args.bin` among its outputs. Naturally they hash `signer.args.bin` and compare it to the proposal's argument hash:

- `out/signer.args.bin` → `367a1124…` (the **Init** args, `ecdsa_key_name = "key_1"`)
- proposal's arg hash → `100d1390…` (`(variant { Upgrade })`)

These will never match. Since #539, upgrade proposals deliberately submit `(variant { Upgrade })` so `post_upgrade` preserves the canister's config instead of re-applying the Init args; the Init args are only for a first install. #539 changed the argument but left this section describing the old world, so the document sends every reviewer down a dead end.

# Changes

- `scripts/proposal-template`: in the Wasm Verification section of both `PROPOSAL.md` and `ROLLBACK.md`, state that `out/signer.wasm.gz` is what the wasm hash is checked against, that `out/signer.args.*` are Init-only and will *not* match, and give the command that reproduces the upgrade argument:
  ```
  didc encode '(variant { Upgrade })' | xxd -r -p | sha256sum
  ```
- Regenerate both golden files.

A rollback is also an upgrade, so it carries the same argument and needed the same wording.

# Tests

- `./scripts/proposal-template.test` passes against the regenerated goldens.
- `shfmt -i 2 -d` and `shellcheck -e SC1090 -e SC2119 -e SC1091` clean on `scripts/proposal-template`.
- Confirmed the documented command reproduces the value it is checked against: it yields `100d1390b7762eef1bc2af9d6fdd157bb800bfc3787142c435d4c28747d0ac30`, matching both the golden proposal's binary argument hash and the on-chain arg hash of live proposal 142929.
