### PR TITLE
chore(ci): Ignore the proposal ID file written by propose

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@
 
 # Release artefacts
 release/
+proposal_id.txt
 
 # rust
 target/


### PR DESCRIPTION
# Motivation

`scripts/propose` writes the submitted proposal ID to `proposal_id.txt` (the default for `--save-proposal-id-to-file`), but that file is not ignored. It shows up as untracked right after a production proposal is submitted, which is exactly when the proposer is least likely to want a stray file in `git status`. Submitting v0.5.1 left `proposal_id.txt` containing `142929`.

It is a build artefact, not source: it is regenerated on every run and is meaningless to anyone else.

# Changes

- Add `proposal_id.txt` to `.gitignore`, under the existing `# Release artefacts` heading next to `release/`, since the same release flow produces it.

# Tests

- `git check-ignore proposal_id.txt` now matches, and `git status` is clean with the file present.
- The file has never been committed, so nothing needs untracking.
