### PR TITLE
fix(ci): Pin the Internet Identity release used by dfx deploy

### DIFF
--- a/dfx.json
+++ b/dfx.json
@@ -77,8 +77,8 @@
 		},
 		"internet_identity": {
 			"type": "custom",
-			"candid": "https://github.com/dfinity/internet-identity/releases/latest/download/internet_identity.did",
-			"wasm": "https://github.com/dfinity/internet-identity/releases/latest/download/internet_identity_dev.wasm.gz",
+			"candid": "https://github.com/dfinity/internet-identity/releases/download/release-2026-07-17/internet_identity.did",
+			"wasm": "https://github.com/dfinity/internet-identity/releases/download/release-2026-07-17/internet_identity_dev.wasm.gz",
 			"remote": {
 				"id": {
 					"staging": "rdmx6-jaaaa-aaaaa-aaadq-cai",


### PR DESCRIPTION
# Motivation

Every open PR is failing the `dfx deploy & integration (ubuntu-24.04)` job at the same step:

```
Failed to install wasm module to canister 'internet_identity'
The replica returned a rejection error: reject code CanisterError
Canister's Wasm module is not valid: Wasm module has an invalid import section.
Module imports function 'msg_caller_info_signer_size' from 'ic0' that is not exported by the runtime.
```

`dfx.json` fetched the `internet_identity` canister from `releases/latest`, so CI tracked whatever Internet Identity published most recently. II `release-2026-07-24` began importing `msg_caller_info_signer_size` from `ic0`, a system API that the replica bundled with the pinned dfx `0.31.0` does not export.

The timing matches exactly: the last green run on `main` was 2026-07-24 at 11:31 UTC, and II `release-2026-07-24` was published at 13:19 UTC the same day. Every run since has picked up a broken `latest`. This is not specific to the Dependabot PRs — those are simply the only PRs currently open; `main` fails the same way if re-run today.

Upgrading dfx is not an option here: the newest dfx is `0.32.0` from 2026-04-22, which predates the new system API entirely.

# Changes

Pin the II candid and wasm URLs to `release-2026-07-17`, the last release whose wasm does not import `msg_caller_info_signer_size`.

This was the only `releases/latest` reference in the repo.

# Tests

Bisected the II releases by downloading each `internet_identity_dev.wasm.gz` and checking for the offending import:

| II release | imports `msg_caller_info_signer_size` |
|---|---|
| `release-2026-07-17` | no — works |
| `release-2026-07-24` | yes |
| `release-2026-07-27` | yes |
| `release-2026-07-28` | yes |
| `release-2026-07-31` | yes |
| `release-2026-08-07` | yes |
| `release-2026-08-11` | yes |
| `release-2026-08-18` | yes |

Verified both pinned assets return HTTP 200 at the `release-2026-07-17` tag, and that `dfx.json` still parses. CI on this PR exercises the actual `dfx deploy`.

# Follow-up

Pinning stops the silent breakage but means II updates now need a manual bump — Dependabot does not track raw URLs in `dfx.json`. Unpinning should wait for a dfx release whose replica exports `msg_caller_info_signer_size`.