### PR TITLE
chore(deps): Bump h2 from 0.4.13 to 0.4.16

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1039,9 +1039,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.13"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+checksum = "a9f37a958b41b3b19ee2707c06439c0e9e547e847223eb791ecb0cb821c65e27"
 dependencies = [
  "atomic-waker",
  "bytes",


### PR DESCRIPTION
Fixes `RUSTSEC-2026-0258` ("h2 unbounded empty DATA frames"), which requires `h2 >= 0.4.16` and is currently failing the `Rust package audit` job.

### Why no dependabot PR does this

`h2` is a *transitive* dependency — `reqwest` and `hyper`, pulled in via the `pocket-ic` dev-dependency — so dependabot never opens a PR for it. It also does not need one: `0.4.16` is semver-compatible with `0.4.13`, so this is a lockfile-only change with no manifest or code impact.

This matters because the vulnerability appeared to create a deadlock (audit red on every PR, seemingly needing a dependabot bump to clear). It did not: nothing had to be merged first.

### Scope of the change

Two lines. Applied as a targeted edit rather than `cargo update -p h2`, because the latter additionally churned five unrelated `windows-sys` entries *downwards* (0.61.2 → 0.52.0/0.59.0/0.60.2) as local resolver drift.

### Verification

- `cargo audit` → exit 0 (only the 5 pre-existing allowed warnings remain: `backoff`, `instant`, `paste`, `anyhow`, `rand`)
- `cargo metadata --locked` → lockfile accepted, so `h2 0.4.16` needs no dependency-set change
- `cargo check --locked --workspace --all-targets` → clean
- `npm audit` → 0 vulnerabilities (the JS side was already fixed on main by the vite bump in #580; dependabot closed #577 as obsolete accordingly)

### Unblocks

This is the sole remaining failing check on #581 and #569.