### PR TITLE
fix(ci): Audit the merge result and re-run the audit on every push

### DIFF
--- a/.github/workflows/security-audit.yaml
+++ b/.github/workflows/security-audit.yaml
@@ -5,6 +5,7 @@ on:
       - opened
       - reopened
       - edited
+      - synchronize
     paths:
       # Run if this action changes.
       - '.github/workflows/security-audit.yaml'
@@ -25,8 +26,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          ref: "${{ github.head_ref || github.ref }}"
       - name: Install cargo audit
         run: scripts/setup cargo-binstall cargo-audit
       - name: Cargo Audit
@@ -36,8 +35,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          ref: "${{ github.head_ref || github.ref }}"
       - name: Audit packages
         run: npm audit
   audit_pass:


### PR DESCRIPTION
Two bugs in `security-audit.yaml` made the audit report verdicts that did not describe the code being proposed for merge. Both surfaced while unblocking the dependabot queue.

### 1. It audited the branch tip, not the merge result

```yaml
- uses: actions/checkout@... # v7.0.0
  with:
    ref: "${{ github.head_ref || github.ref }}"
```

This checks out the PR branch as-is, so every PR was audited against *its own* snapshot of `Cargo.lock` / `package-lock.json` rather than against the state merging would produce. Stale branches consequently failed on vulnerabilities `main` had already fixed — #583 failed the JS audit on the `nanoid` and `postcss` advisories that #580 had already resolved on `main`, where `npm audit` reports 0 vulnerabilities.

This is the failure mode that made the queue look deadlocked: an audit red on a PR that does not contain the vulnerability reads as "this PR must merge something else first".

Dropping the override lets `actions/checkout` use the merge commit for `pull_request` events. `schedule` and `workflow_dispatch` behaviour is unchanged — with no override, non-PR events already check out `github.ref`, exactly what the removed expression fell back to.

### 2. It never re-ran on new commits

`types:` listed `opened`, `reopened`, `edited` — but not `synchronize`, so pushing to a PR never refreshed its audit verdict.

After rebasing 8 dependabot PRs, 5 of them (#583, #579, #570, #557, #554) ended up with **no audit check at all**, because a rebase is a force-push and nothing re-triggered the workflow. The two that did re-run (#581, #569) only did so because their bodies happened to be edited. Before the rebases, #554, #557 and #570 were still showing green `audit_pass` results from runs months old.

A missing check is worse than a red one: those PRs read as fully green with the security gate silently absent.

### Note on making this a required check

`audit_pass` is currently **not** a required status check — the ruleset requires only `pr-pass` and `Checks pass`. So this gate is advisory today, which is worth knowing given how much the red X influenced triage.

I have deliberately not changed that here. Because the workflow is `paths`-filtered, it does not run on PRs that touch no manifest or lockfile (e.g. #570, an actions bump), and a required check that never reports blocks a PR indefinitely. Making `audit_pass` required wants either dropping the `paths` filter or a skip-aware always-reporting job — worth doing, but a separate decision from these two fixes.